### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
     "codecompanion-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1754068529,
-        "narHash": "sha256-ZHEceu2dxmUiHPzK7maXnEtVijDGthFIYtpiOY4h7DA=",
+        "lastModified": 1754561654,
+        "narHash": "sha256-zY9uWB11mr/XDAw/l4HLAy3ZHaIhUiYlzUFbiKVFSvg=",
         "owner": "olimorris",
         "repo": "codecompanion.nvim",
-        "rev": "6b8480ee5ddb9294f3fe21f526d36dfa4d15f06a",
+        "rev": "19d665a9b13c0b05652c359c4302465b8b2543be",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753121425,
-        "narHash": "sha256-TVcTNvOeWWk1DXljFxVRp+E0tzG1LhrVjOGGoMHuXio=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "644e0fc48951a860279da645ba77fe4a6e814c5e",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -319,11 +319,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750779888,
-        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
+        "lastModified": 1754416808,
+        "narHash": "sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef+6fRcofA=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
         "type": "github"
       },
       "original": {
@@ -401,11 +401,11 @@
     "hop-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1740592943,
-        "narHash": "sha256-gHRKkqAMrQmpPHEWGETj3KG0NqwCnlTT8z/cNmug/Xc=",
+        "lastModified": 1754504110,
+        "narHash": "sha256-gu9nOdo58V5t/WSe6Mbl4LY0g8VBH0R7fgArqv0WsyA=",
         "owner": "smoka7",
         "repo": "hop.nvim",
-        "rev": "9c6a1dd9afb53a112b128877ccd583a1faa0b8b6",
+        "rev": "2254e0b3c8054b9ee661c9be3cb201d4b3384d8e",
         "type": "github"
       },
       "original": {
@@ -468,11 +468,11 @@
     "lavish-layouts-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1753804266,
-        "narHash": "sha256-GCqNLBlKlTnuYmXjR8bZ4TNunEhidij7rTURqLDX8v4=",
+        "lastModified": 1754256310,
+        "narHash": "sha256-02sk11tKvsT+R+UMGFmYGehD+sQuBUFiij0T+F/VtOU=",
         "owner": "dkuettel",
         "repo": "lavish-layouts.nvim",
-        "rev": "dc414d1305e490a38bcfdb7ffae555910cf66217",
+        "rev": "6862bce269f99518d93264d8100a91b1e2d93c67",
         "type": "github"
       },
       "original": {
@@ -575,11 +575,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1754050710,
-        "narHash": "sha256-zGGx7XFSJd1mRIrUrDbjKGXDjfk/aPRToDbLrshLbUU=",
+        "lastModified": 1754641381,
+        "narHash": "sha256-eMoujl/X1lbdjRbC/HHCpZmUb5tqTAYSL1hocy+o7nc=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "84d2911ae6b97e160ed8de8ece7bd1068c2bf686",
+        "rev": "83aaf3085f808dec9ea1b5d16b216875a8081b37",
         "type": "github"
       },
       "original": {
@@ -591,11 +591,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1753992225,
-        "narHash": "sha256-QUlWhBgDm9No+RkI33faSqsSZNU/QhZjMOP333FjN38=",
+        "lastModified": 1754610154,
+        "narHash": "sha256-ORfF40X4BGiFxnLNQbdsQbUTW4TkUHfPqyZWHaYL5NE=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "c3a4d125296caaf15ff424e7609e731a8b4d37e7",
+        "rev": "038eb01b41b66379f75164507571497929f8847c",
         "type": "github"
       },
       "original": {
@@ -656,11 +656,11 @@
         "web-devicons-nvim": "web-devicons-nvim"
       },
       "locked": {
-        "lastModified": 1754671992,
-        "narHash": "sha256-hdx7xhJyNrd4wBKMr7onxC8aR0wGTqITBf4qsVMDzyo=",
+        "lastModified": 1754760994,
+        "narHash": "sha256-6Rk94qxEcWzru2Jmpb5ZusFpU012DrPECGL1tLZ/m2U=",
         "owner": "iff",
         "repo": "nihilistic-nvim",
-        "rev": "b3078d896489aaf412df70b432b605f5a3bc9d06",
+        "rev": "041392fb1371d28e6411eddb453cb5d62512afda",
         "type": "github"
       },
       "original": {
@@ -736,11 +736,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1754018889,
-        "narHash": "sha256-0iNMc5mOygNUgsX9+/V88bIVNheSJxxsIWojsOgD/Jg=",
+        "lastModified": 1754445803,
+        "narHash": "sha256-FJGFwDeA0HxEEawnytdH663aFdf7lKKTwDZw9XX3Jxg=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "d0dbf489a8810672fa9a61f4a86e5cf89214b772",
+        "rev": "9141be4c1332afc83bdf1b0278dbb030f75ff8e3",
         "type": "github"
       },
       "original": {
@@ -1026,11 +1026,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753772294,
-        "narHash": "sha256-8rkd13WfClfZUBIYpX5dvG3O9V9w3K9FPQ9rY14VtBE=",
+        "lastModified": 1754492133,
+        "narHash": "sha256-B+3g9+76KlGe34Yk9za8AF3RL+lnbHXkLiVHLjYVOAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6b9214fffbcf3f1e608efa15044431651635ca83",
+        "rev": "1298185c05a56bff66383a20be0b41a307f52228",
         "type": "github"
       },
       "original": {
@@ -1069,11 +1069,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1753653538,
-        "narHash": "sha256-1IwOcdIUJuh7YC2YTw0VnGI2UIg7F/ipxLLfQdPzjFQ=",
+        "lastModified": 1754086681,
+        "narHash": "sha256-OzLLsrDaAHcNqasrHiL0hRNH9XZtCyoKrUFeSt/Iol8=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "4a8369f4c78ef6f6f895f0cec349e48f74330574",
+        "rev": "3362099de3368aa620a8105b19ed04c2053e38c0",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754060289,
-        "narHash": "sha256-rWc9WUHtDCnHhnKEbiyLwBmvsXxHgBf56jvmmHPMUCk=",
+        "lastModified": 1754613544,
+        "narHash": "sha256-ueR1mGX4I4DWfDRRxxMphbKDNisDeMPMusN72VV1+cc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "19f94a3e0e6c8573ea58dac685e96c36e2526cfa",
+        "rev": "cc2fa2331aebf9661d22bb507d362b39852ac73f",
         "type": "github"
       },
       "original": {
@@ -656,11 +656,11 @@
         "web-devicons-nvim": "web-devicons-nvim"
       },
       "locked": {
-        "lastModified": 1754298786,
-        "narHash": "sha256-4SuvsTrpcYJvBK3b92XfF+EOETdlbuKWM7CPXNn0Ebk=",
+        "lastModified": 1754671992,
+        "narHash": "sha256-hdx7xhJyNrd4wBKMr7onxC8aR0wGTqITBf4qsVMDzyo=",
         "owner": "iff",
         "repo": "nihilistic-nvim",
-        "rev": "92ef27264d37f389f3b65458bf4d256ec93d2f44",
+        "rev": "b3078d896489aaf412df70b432b605f5a3bc9d06",
         "type": "github"
       },
       "original": {
@@ -703,11 +703,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1754060105,
-        "narHash": "sha256-di5L6e5Iiv+oegS07j9h23FdqEpXn0ZQqMlDOEMw1EY=",
+        "lastModified": 1754640348,
+        "narHash": "sha256-dSSzu/afJLQIr10WRJuKucZ387YvRXmz1iABwD6SB7E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7eabdc701d7dbb810fd91a97ec358caa4c1fc50",
+        "rev": "a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/19f94a3e0e6c8573ea58dac685e96c36e2526cfa' (2025-08-01)
  → 'github:nix-community/home-manager/cc2fa2331aebf9661d22bb507d362b39852ac73f' (2025-08-08)
• Updated input 'nihilistic-nvim':
    'github:iff/nihilistic-nvim/92ef27264d37f389f3b65458bf4d256ec93d2f44' (2025-08-04)
  → 'github:iff/nihilistic-nvim/b3078d896489aaf412df70b432b605f5a3bc9d06' (2025-08-08)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e7eabdc701d7dbb810fd91a97ec358caa4c1fc50' (2025-08-01)
  → 'github:nixos/nixpkgs/a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1' (2025-08-08)

```

</p></details>

 - Updated input [`nihilistic-nvim`](https://github.com/iff/nihilistic-nvim): [`92ef2726` ➡️ `b3078d89`](https://github.com/iff/nihilistic-nvim/compare/92ef27264d37f389f3b65458bf4d256ec93d2f44...b3078d896489aaf412df70b432b605f5a3bc9d06) <sub>(2025-08-04 to 2025-08-08)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`e7eabdc7` ➡️ `a3f3e3f2`](https://github.com/nixos/nixpkgs/compare/e7eabdc701d7dbb810fd91a97ec358caa4c1fc50...a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1) <sub>(2025-08-01 to 2025-08-08)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`19f94a3e` ➡️ `cc2fa233`](https://github.com/nix-community/home-manager/compare/19f94a3e0e6c8573ea58dac685e96c36e2526cfa...cc2fa2331aebf9661d22bb507d362b39852ac73f) <sub>(2025-08-01 to 2025-08-08)</sub>