### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -798,11 +798,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754613544,
-        "narHash": "sha256-ueR1mGX4I4DWfDRRxxMphbKDNisDeMPMusN72VV1+cc=",
+        "lastModified": 1755229570,
+        "narHash": "sha256-soZegto0xXzG2zYlu/zjknDHv0Z7tRS5EQs+Z/VRTBg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cc2fa2331aebf9661d22bb507d362b39852ac73f",
+        "rev": "11626a4383b458f8dc5ea3237eaa04e8ab1912f3",
         "type": "github"
       },
       "original": {
@@ -1461,11 +1461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1754640348,
-        "narHash": "sha256-dSSzu/afJLQIr10WRJuKucZ387YvRXmz1iABwD6SB7E=",
+        "lastModified": 1755175540,
+        "narHash": "sha256-V0j2S1r25QnbqBLzN2Rg/dKKil789bI3P3id7bDPVc4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1",
+        "rev": "a595dde4d0d31606e19dcec73db02279db59d201",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/cc2fa2331aebf9661d22bb507d362b39852ac73f' (2025-08-08)
  → 'github:nix-community/home-manager/11626a4383b458f8dc5ea3237eaa04e8ab1912f3' (2025-08-15)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1' (2025-08-08)
  → 'github:nixos/nixpkgs/a595dde4d0d31606e19dcec73db02279db59d201' (2025-08-14)

```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`a3f3e3f2` ➡️ `a595dde4`](https://github.com/nixos/nixpkgs/compare/a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1...a595dde4d0d31606e19dcec73db02279db59d201) <sub>(2025-08-08 to 2025-08-14)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`cc2fa233` ➡️ `11626a43`](https://github.com/nix-community/home-manager/compare/cc2fa2331aebf9661d22bb507d362b39852ac73f...11626a4383b458f8dc5ea3237eaa04e8ab1912f3) <sub>(2025-08-08 to 2025-08-15)</sub>