### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755229570,
-        "narHash": "sha256-soZegto0xXzG2zYlu/zjknDHv0Z7tRS5EQs+Z/VRTBg=",
+        "lastModified": 1755810213,
+        "narHash": "sha256-QdenO8f0PTg+tC6HuSvngKcbRZA5oZKmjUT+MXKOLQg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "11626a4383b458f8dc5ea3237eaa04e8ab1912f3",
+        "rev": "6911d3e7f475f7b3558b4f5a6aba90fa86099baa",
         "type": "github"
       },
       "original": {
@@ -419,11 +419,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1753252360,
-        "narHash": "sha256-PFAJoEqQWMlo1J+yZb+4HixmhbRVmmNl58e/AkLYDDI=",
+        "lastModified": 1755680610,
+        "narHash": "sha256-g7/g5o0spemkZCzPa8I21RgCmN0Kv41B5z9Z5HQWraY=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "6839b23345b71db17cd408373de4f5605bf589b8",
+        "rev": "04721247f417256ca96acf28cdfe946cf1006263",
         "type": "github"
       },
       "original": {
@@ -639,11 +639,11 @@
         "web-devicons-nvim": "web-devicons-nvim"
       },
       "locked": {
-        "lastModified": 1755525495,
-        "narHash": "sha256-81t55yjJIp8bw/4Ik7RpfO/CS3lvrktvfftZo/INeiI=",
+        "lastModified": 1755585143,
+        "narHash": "sha256-COstsSlalHV7Q2yInXFUvF6NEjhFxR6fdLqphvEgX8I=",
         "owner": "iff",
         "repo": "nihilistic-nvim",
-        "rev": "0fcc03eebc738dac2796184f95089d7f92b2ecac",
+        "rev": "ed828d3d7b006aa65a18f05f0215304fe0fc4d9a",
         "type": "github"
       },
       "original": {
@@ -686,11 +686,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1755175540,
-        "narHash": "sha256-V0j2S1r25QnbqBLzN2Rg/dKKil789bI3P3id7bDPVc4=",
+        "lastModified": 1755736253,
+        "narHash": "sha256-jlIQRypNhB1PcB1BE+expE4xZeJxzoAGr1iUbHQta8s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a595dde4d0d31606e19dcec73db02279db59d201",
+        "rev": "596312aae91421d6923f18cecce934a7d3bfd6b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/11626a4383b458f8dc5ea3237eaa04e8ab1912f3' (2025-08-15)
  → 'github:nix-community/home-manager/6911d3e7f475f7b3558b4f5a6aba90fa86099baa' (2025-08-21)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/6839b23345b71db17cd408373de4f5605bf589b8' (2025-07-23)
  → 'github:hyprwm/contrib/04721247f417256ca96acf28cdfe946cf1006263' (2025-08-20)
• Updated input 'nihilistic-nvim':
    'github:iff/nihilistic-nvim/0fcc03eebc738dac2796184f95089d7f92b2ecac' (2025-08-18)
  → 'github:iff/nihilistic-nvim/ed828d3d7b006aa65a18f05f0215304fe0fc4d9a' (2025-08-19)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a595dde4d0d31606e19dcec73db02279db59d201' (2025-08-14)
  → 'github:nixos/nixpkgs/596312aae91421d6923f18cecce934a7d3bfd6b8' (2025-08-21)

```

</p></details>

 - Updated input [`nihilistic-nvim`](https://github.com/iff/nihilistic-nvim): [`0fcc03ee` ➡️ `ed828d3d`](https://github.com/iff/nihilistic-nvim/compare/0fcc03eebc738dac2796184f95089d7f92b2ecac...ed828d3d7b006aa65a18f05f0215304fe0fc4d9a) <sub>(2025-08-18 to 2025-08-19)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`6839b233` ➡️ `04721247`](https://github.com/hyprwm/contrib/compare/6839b23345b71db17cd408373de4f5605bf589b8...04721247f417256ca96acf28cdfe946cf1006263) <sub>(2025-07-23 to 2025-08-20)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`a595dde4` ➡️ `596312aa`](https://github.com/nixos/nixpkgs/compare/a595dde4d0d31606e19dcec73db02279db59d201...596312aae91421d6923f18cecce934a7d3bfd6b8) <sub>(2025-08-14 to 2025-08-21)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`11626a43` ➡️ `6911d3e7`](https://github.com/nix-community/home-manager/compare/11626a4383b458f8dc5ea3237eaa04e8ab1912f3...6911d3e7f475f7b3558b4f5a6aba90fa86099baa) <sub>(2025-08-15 to 2025-08-21)</sub>