### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755810213,
-        "narHash": "sha256-QdenO8f0PTg+tC6HuSvngKcbRZA5oZKmjUT+MXKOLQg=",
+        "lastModified": 1756496801,
+        "narHash": "sha256-IYIsnPy+cJxe8RbDHBrCtfJY0ry2bG2H7WvMcewiGS8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6911d3e7f475f7b3558b4f5a6aba90fa86099baa",
+        "rev": "77a71380c38fb2a440b4b5881bbc839f6230e1cb",
         "type": "github"
       },
       "original": {
@@ -686,11 +686,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1755736253,
-        "narHash": "sha256-jlIQRypNhB1PcB1BE+expE4xZeJxzoAGr1iUbHQta8s=",
+        "lastModified": 1756381814,
+        "narHash": "sha256-tzo7YvAsGlzo4WiIHT0ooR59VHu+aKRQdHk7sIyoia4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "596312aae91421d6923f18cecce934a7d3bfd6b8",
+        "rev": "aca2499b79170038df0dbaec8bf2f689b506ad32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/6911d3e7f475f7b3558b4f5a6aba90fa86099baa' (2025-08-21)
  → 'github:nix-community/home-manager/77a71380c38fb2a440b4b5881bbc839f6230e1cb' (2025-08-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/596312aae91421d6923f18cecce934a7d3bfd6b8' (2025-08-21)
  → 'github:nixos/nixpkgs/aca2499b79170038df0dbaec8bf2f689b506ad32' (2025-08-28)

```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`596312aa` ➡️ `aca2499b`](https://github.com/nixos/nixpkgs/compare/596312aae91421d6923f18cecce934a7d3bfd6b8...aca2499b79170038df0dbaec8bf2f689b506ad32) <sub>(2025-08-21 to 2025-08-28)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`6911d3e7` ➡️ `77a71380`](https://github.com/nix-community/home-manager/compare/6911d3e7f475f7b3558b4f5a6aba90fa86099baa...77a71380c38fb2a440b4b5881bbc839f6230e1cb) <sub>(2025-08-21 to 2025-08-29)</sub>