### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756496801,
-        "narHash": "sha256-IYIsnPy+cJxe8RbDHBrCtfJY0ry2bG2H7WvMcewiGS8=",
+        "lastModified": 1757075491,
+        "narHash": "sha256-a+NMGl5tcvm+hyfSG2DlVPa8nZLpsumuRj1FfcKb2mQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "77a71380c38fb2a440b4b5881bbc839f6230e1cb",
+        "rev": "f56bf065f9abedc7bc15e1f2454aa5c8edabaacf",
         "type": "github"
       },
       "original": {
@@ -669,11 +669,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1756381814,
-        "narHash": "sha256-tzo7YvAsGlzo4WiIHT0ooR59VHu+aKRQdHk7sIyoia4=",
+        "lastModified": 1756911493,
+        "narHash": "sha256-6n/n1GZQ/vi+LhFXMSyoseKdNfc2QQaSBXJdgamrbkE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "aca2499b79170038df0dbaec8bf2f689b506ad32",
+        "rev": "c6a788f552b7b7af703b1a29802a7233c0067908",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/77a71380c38fb2a440b4b5881bbc839f6230e1cb' (2025-08-29)
  → 'github:nix-community/home-manager/f56bf065f9abedc7bc15e1f2454aa5c8edabaacf' (2025-09-05)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/aca2499b79170038df0dbaec8bf2f689b506ad32' (2025-08-28)
  → 'github:nixos/nixpkgs/c6a788f552b7b7af703b1a29802a7233c0067908' (2025-09-03)

```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`aca2499b` ➡️ `c6a788f5`](https://github.com/nixos/nixpkgs/compare/aca2499b79170038df0dbaec8bf2f689b506ad32...c6a788f552b7b7af703b1a29802a7233c0067908) <sub>(2025-08-28 to 2025-09-03)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`77a71380` ➡️ `f56bf065`](https://github.com/nix-community/home-manager/compare/77a71380c38fb2a440b4b5881bbc839f6230e1cb...f56bf065f9abedc7bc15e1f2454aa5c8edabaacf) <sub>(2025-08-29 to 2025-09-05)</sub>