### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757075491,
-        "narHash": "sha256-a+NMGl5tcvm+hyfSG2DlVPa8nZLpsumuRj1FfcKb2mQ=",
+        "lastModified": 1757698511,
+        "narHash": "sha256-UqHHGydF/q3jfYXCpvYLA0TWtvByOp1NwOKCUjhYmPs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f56bf065f9abedc7bc15e1f2454aa5c8edabaacf",
+        "rev": "a3fcc92180c7462082cd849498369591dfb20855",
         "type": "github"
       },
       "original": {
@@ -669,11 +669,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1756911493,
-        "narHash": "sha256-6n/n1GZQ/vi+LhFXMSyoseKdNfc2QQaSBXJdgamrbkE=",
+        "lastModified": 1757651841,
+        "narHash": "sha256-Lh9QoMzTjY/O4LqNwcm6s/WSYStDmCH6f3V/izwlkHc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c6a788f552b7b7af703b1a29802a7233c0067908",
+        "rev": "ad4e6dd68c30bc8bd1860a27bc6f0c485bd7f3b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/f56bf065f9abedc7bc15e1f2454aa5c8edabaacf' (2025-09-05)
  → 'github:nix-community/home-manager/a3fcc92180c7462082cd849498369591dfb20855' (2025-09-12)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/c6a788f552b7b7af703b1a29802a7233c0067908' (2025-09-03)
  → 'github:nixos/nixpkgs/ad4e6dd68c30bc8bd1860a27bc6f0c485bd7f3b6' (2025-09-12)

```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`c6a788f5` ➡️ `ad4e6dd6`](https://github.com/nixos/nixpkgs/compare/c6a788f552b7b7af703b1a29802a7233c0067908...ad4e6dd68c30bc8bd1860a27bc6f0c485bd7f3b6) <sub>(2025-09-03 to 2025-09-12)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`f56bf065` ➡️ `a3fcc921`](https://github.com/nix-community/home-manager/compare/f56bf065f9abedc7bc15e1f2454aa5c8edabaacf...a3fcc92180c7462082cd849498369591dfb20855) <sub>(2025-09-05 to 2025-09-12)</sub>