### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757698511,
-        "narHash": "sha256-UqHHGydF/q3jfYXCpvYLA0TWtvByOp1NwOKCUjhYmPs=",
+        "lastModified": 1758296614,
+        "narHash": "sha256-l60D1i0aaSqemy9dL7wP0ePMfcv/oZbeKpvUMY+q0kQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a3fcc92180c7462082cd849498369591dfb20855",
+        "rev": "55b1f5b7b191572257545413b98e37abab2fdb00",
         "type": "github"
       },
       "original": {
@@ -403,11 +403,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1755680610,
-        "narHash": "sha256-g7/g5o0spemkZCzPa8I21RgCmN0Kv41B5z9Z5HQWraY=",
+        "lastModified": 1758055182,
+        "narHash": "sha256-0TCggLT5bUMpJYoA8+EXs8Qu+D9sTVe6eOmsNetH8OI=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "04721247f417256ca96acf28cdfe946cf1006263",
+        "rev": "9e73a0e753251fbc6e987bd13324886dc6ca8f9a",
         "type": "github"
       },
       "original": {
@@ -605,11 +605,11 @@
         "web-devicons-nvim": "web-devicons-nvim"
       },
       "locked": {
-        "lastModified": 1758004756,
-        "narHash": "sha256-seEvR0yLSIw29wPegFBXLxFGZ42J5rMJmF41DgzsoLE=",
+        "lastModified": 1758050802,
+        "narHash": "sha256-hdM0nHHFkRJ6ykeg99YJ6R31LDbxLqWoCPL1GJRtXj4=",
         "owner": "iff",
         "repo": "nihilistic-nvim",
-        "rev": "3a9f1e335647a11b08d58cf131bace7480463e5a",
+        "rev": "ae59c9e03ebbe90893e30d8ca06636238527c760",
         "type": "github"
       },
       "original": {
@@ -652,11 +652,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1757746433,
-        "narHash": "sha256-fEvTiU4s9lWgW7mYEU/1QUPirgkn+odUBTaindgiziY=",
+        "lastModified": 1758262103,
+        "narHash": "sha256-aBGl3XEOsjWw6W3AHiKibN7FeoG73dutQQEqnd/etR8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6d7ec06d6868ac6d94c371458fc2391ded9ff13d",
+        "rev": "12bd230118a1901a4a5d393f9f56b6ad7e571d01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/a3fcc92180c7462082cd849498369591dfb20855' (2025-09-12)
  → 'github:nix-community/home-manager/55b1f5b7b191572257545413b98e37abab2fdb00' (2025-09-19)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/04721247f417256ca96acf28cdfe946cf1006263' (2025-08-20)
  → 'github:hyprwm/contrib/9e73a0e753251fbc6e987bd13324886dc6ca8f9a' (2025-09-16)
• Updated input 'nihilistic-nvim':
    'github:iff/nihilistic-nvim/3a9f1e335647a11b08d58cf131bace7480463e5a' (2025-09-16)
  → 'github:iff/nihilistic-nvim/ae59c9e03ebbe90893e30d8ca06636238527c760' (2025-09-16)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/6d7ec06d6868ac6d94c371458fc2391ded9ff13d' (2025-09-13)
  → 'github:nixos/nixpkgs/12bd230118a1901a4a5d393f9f56b6ad7e571d01' (2025-09-19)

```

</p></details>

 - Updated input [`nihilistic-nvim`](https://github.com/iff/nihilistic-nvim): [`3a9f1e33` ➡️ `ae59c9e0`](https://github.com/iff/nihilistic-nvim/compare/3a9f1e335647a11b08d58cf131bace7480463e5a...ae59c9e03ebbe90893e30d8ca06636238527c760) <sub>(2025-09-16 to 2025-09-16)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`04721247` ➡️ `9e73a0e7`](https://github.com/hyprwm/contrib/compare/04721247f417256ca96acf28cdfe946cf1006263...9e73a0e753251fbc6e987bd13324886dc6ca8f9a) <sub>(2025-08-20 to 2025-09-16)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`6d7ec06d` ➡️ `12bd2301`](https://github.com/nixos/nixpkgs/compare/6d7ec06d6868ac6d94c371458fc2391ded9ff13d...12bd230118a1901a4a5d393f9f56b6ad7e571d01) <sub>(2025-09-13 to 2025-09-19)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`a3fcc921` ➡️ `55b1f5b7`](https://github.com/nix-community/home-manager/compare/a3fcc92180c7462082cd849498369591dfb20855...55b1f5b7b191572257545413b98e37abab2fdb00) <sub>(2025-09-12 to 2025-09-19)</sub>