### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758296614,
-        "narHash": "sha256-l60D1i0aaSqemy9dL7wP0ePMfcv/oZbeKpvUMY+q0kQ=",
+        "lastModified": 1758916421,
+        "narHash": "sha256-i4vGfcRJpLIWjWzXPzsyhP4cCPJu1bzoY0eMGxRK5SI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "55b1f5b7b191572257545413b98e37abab2fdb00",
+        "rev": "497e2bfa8a45bebe9788e2aa13e766e6a96677cd",
         "type": "github"
       },
       "original": {
@@ -257,11 +257,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1758055182,
-        "narHash": "sha256-0TCggLT5bUMpJYoA8+EXs8Qu+D9sTVe6eOmsNetH8OI=",
+        "lastModified": 1758531979,
+        "narHash": "sha256-iRv5afKzuu6SkwztqMwZ33161CzBJsyeRHp0uviN9TI=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "9e73a0e753251fbc6e987bd13324886dc6ca8f9a",
+        "rev": "de79078fd59140067e53cd00ebdf17f96ce27846",
         "type": "github"
       },
       "original": {
@@ -462,11 +462,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1758262103,
-        "narHash": "sha256-aBGl3XEOsjWw6W3AHiKibN7FeoG73dutQQEqnd/etR8=",
+        "lastModified": 1758763312,
+        "narHash": "sha256-puBMviZhYlqOdUUgEmMVJpXqC/ToEqSvkyZ30qQ09xM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "12bd230118a1901a4a5d393f9f56b6ad7e571d01",
+        "rev": "e57b3b16ad8758fd681511a078f35c416a8cc939",
         "type": "github"
       },
       "original": {
@@ -517,11 +517,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1758653676,
-        "narHash": "sha256-n47ZG3Txh8Wc3V4dxRWGpmi6mNykwxNs3Nn1+k8apbk=",
+        "lastModified": 1758887862,
+        "narHash": "sha256-7ogD459Ta7RcAVNHAbw849l1Oo3xPO8y9dOQzE4Jh1Y=",
         "owner": "iff",
         "repo": "osh-oxy",
-        "rev": "c5872567ac3fbecfdd19ff11869cb63c7b0c8d66",
+        "rev": "670c5e431912ab96c0fae60bc982830a0f42eb9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/55b1f5b7b191572257545413b98e37abab2fdb00' (2025-09-19)
  → 'github:nix-community/home-manager/497e2bfa8a45bebe9788e2aa13e766e6a96677cd' (2025-09-26)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/9e73a0e753251fbc6e987bd13324886dc6ca8f9a' (2025-09-16)
  → 'github:hyprwm/contrib/de79078fd59140067e53cd00ebdf17f96ce27846' (2025-09-22)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/12bd230118a1901a4a5d393f9f56b6ad7e571d01' (2025-09-19)
  → 'github:nixos/nixpkgs/e57b3b16ad8758fd681511a078f35c416a8cc939' (2025-09-25)
• Updated input 'osh-oxy':
    'github:iff/osh-oxy/c5872567ac3fbecfdd19ff11869cb63c7b0c8d66' (2025-09-23)
  → 'github:iff/osh-oxy/670c5e431912ab96c0fae60bc982830a0f42eb9e' (2025-09-26)

```

</p></details>

 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`9e73a0e7` ➡️ `de79078f`](https://github.com/hyprwm/contrib/compare/9e73a0e753251fbc6e987bd13324886dc6ca8f9a...de79078fd59140067e53cd00ebdf17f96ce27846) <sub>(2025-09-16 to 2025-09-22)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`12bd2301` ➡️ `e57b3b16`](https://github.com/nixos/nixpkgs/compare/12bd230118a1901a4a5d393f9f56b6ad7e571d01...e57b3b16ad8758fd681511a078f35c416a8cc939) <sub>(2025-09-19 to 2025-09-25)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`55b1f5b7` ➡️ `497e2bfa`](https://github.com/nix-community/home-manager/compare/55b1f5b7b191572257545413b98e37abab2fdb00...497e2bfa8a45bebe9788e2aa13e766e6a96677cd) <sub>(2025-09-19 to 2025-09-26)</sub>
 - Updated input [`osh-oxy`](https://github.com/iff/osh-oxy): [`c5872567` ➡️ `670c5e43`](https://github.com/iff/osh-oxy/compare/c5872567ac3fbecfdd19ff11869cb63c7b0c8d66...670c5e431912ab96c0fae60bc982830a0f42eb9e) <sub>(2025-09-23 to 2025-09-26)</sub>