### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,6 +96,112 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "neorocks",
+          "neovim-nightly",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -216,6 +322,168 @@
         "type": "github"
       }
     },
+    "gen-luarc": {
+      "inputs": {
+        "flake-parts": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "git-hooks"
+        ],
+        "luvit-meta": "luvit-meta",
+        "nixpkgs": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1755304025,
+        "narHash": "sha256-xVKfjFwc0zMbLMjLTiHz+0llggkjs93SmHkhaa9S3M4=",
+        "owner": "mrcjkb",
+        "repo": "nix-gen-luarc-json",
+        "rev": "1865b0ebb753ae5324d7381b1fa8c98c04ec7509",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mrcjkb",
+        "repo": "nix-gen-luarc-json",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1758108966,
+        "narHash": "sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "gitignore": "gitignore_2",
+        "nixpkgs": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "neorocks",
+          "neovim-nightly",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1758108966,
+        "narHash": "sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "neorocks",
+          "neovim-nightly",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "hercules-ci-effects": {
+      "inputs": {
+        "flake-parts": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "neorocks",
+          "neovim-nightly",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "neorocks",
+          "neovim-nightly",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1758022363,
+        "narHash": "sha256-ENUhCRWgSX4ni751HieNuQoq06dJvApV/Nm89kh+/A0=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "1a3667d33e247ad35ca250698d63f49a5453d824",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -223,11 +491,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758916421,
-        "narHash": "sha256-i4vGfcRJpLIWjWzXPzsyhP4cCPJu1bzoY0eMGxRK5SI=",
+        "lastModified": 1759519282,
+        "narHash": "sha256-Wj76KLk49eRS086h6Fh0si95P6qqpzO7Gno9/nI336E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "497e2bfa8a45bebe9788e2aa13e766e6a96677cd",
+        "rev": "bd92e8ee4a6031ca3dd836c91dc41c13fca1e533",
         "type": "github"
       },
       "original": {
@@ -257,11 +525,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1758531979,
-        "narHash": "sha256-iRv5afKzuu6SkwztqMwZ33161CzBJsyeRHp0uviN9TI=",
+        "lastModified": 1759238633,
+        "narHash": "sha256-4/AtRCQKXuU49ozZZouWuC+T7vCjQh9HAz3N8Tt5OZE=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "de79078fd59140067e53cd00ebdf17f96ce27846",
+        "rev": "513d71d3f42c05d6a38e215382c5a6ce971bd77d",
         "type": "github"
       },
       "original": {
@@ -367,6 +635,96 @@
         "type": "github"
       }
     },
+    "luvit-meta": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705776742,
+        "narHash": "sha256-zAAptV/oLuLAAsa2zSB/6fxlElk4+jNZd/cPr9oxFig=",
+        "owner": "Bilal2453",
+        "repo": "luvit-meta",
+        "rev": "ce76f6f6cdc9201523a5875a4471dcfe0186eb60",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Bilal2453",
+        "repo": "luvit-meta",
+        "type": "github"
+      }
+    },
+    "neorocks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-parts": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "git-hooks"
+        ],
+        "neovim-nightly": "neovim-nightly",
+        "nixpkgs": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1758950882,
+        "narHash": "sha256-s2aVgfHQx9LSqPOLfkny/HaIuVj46VyER8sgq++cRI0=",
+        "owner": "nvim-neorocks",
+        "repo": "neorocks",
+        "rev": "fc9288c539d83adae5356b18dea8187ba380dd56",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvim-neorocks",
+        "repo": "neorocks",
+        "type": "github"
+      }
+    },
+    "neovim-nightly": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "flake-parts": "flake-parts_2",
+        "git-hooks": "git-hooks_2",
+        "hercules-ci-effects": "hercules-ci-effects",
+        "neovim-src": "neovim-src",
+        "nixpkgs": "nixpkgs_3",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1758931509,
+        "narHash": "sha256-NFOXeqUwhH+V+XXJP3Z8RRzjulOzokwOPQ2kbDuFvX8=",
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "rev": "93318bab5ce403a60a694ad1b6219760935553f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "type": "github"
+      }
+    },
+    "neovim-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758863424,
+        "narHash": "sha256-fYY8JrOuqovlOcXfryf2xiahBPTXHQExFpMIsur69/A=",
+        "owner": "neovim",
+        "repo": "neovim",
+        "rev": "a0c60e819df1b4d4ae5ac631d48e874fa1cf9b92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "neovim",
+        "repo": "neovim",
+        "type": "github"
+      }
+    },
     "nightfox-nvim": {
       "flake": false,
       "locked": {
@@ -408,6 +766,7 @@
         "nvim-lspconfig": "nvim-lspconfig",
         "ptags-nvim": "ptags-nvim",
         "resty-vim": "resty-vim",
+        "rustacean-nvim": "rustacean-nvim",
         "telescope-fzf-native-nvim": "telescope-fzf-native-nvim",
         "telescope-hop-nvim": "telescope-hop-nvim",
         "telescope-nvim": "telescope-nvim",
@@ -415,11 +774,11 @@
         "web-devicons-nvim": "web-devicons-nvim"
       },
       "locked": {
-        "lastModified": 1759143723,
-        "narHash": "sha256-Vn6VGaELAOEaZZmWBSvbL46sgaP0mwSNdnQo3IKAzdQ=",
+        "lastModified": 1759166257,
+        "narHash": "sha256-nhWlaNcpAv2ThxENYzCouMAwfmMrGBU4a1V2/6kRp4Y=",
         "owner": "iff",
         "repo": "nihilistic-nvim",
-        "rev": "5a0da3d98dd24983db4b49bb81bb3017bf0c776a",
+        "rev": "985e56679b005a23515f818d0922e76595d4662c",
         "type": "github"
       },
       "original": {
@@ -444,6 +803,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1753345091,
@@ -464,9 +838,25 @@
       "locked": {
         "lastModified": 1758763312,
         "narHash": "sha256-puBMviZhYlqOdUUgEmMVJpXqC/ToEqSvkyZ30qQ09xM=",
-        "owner": "nixos",
+        "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "e57b3b16ad8758fd681511a078f35c416a8cc939",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1758916627,
+        "narHash": "sha256-fB2ISCc+xn+9hZ6gOsABxSBcsCgLCjbJ5bC6U9bPzQ4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "53614373268559d054c080d070cfc732dbe68ac4",
         "type": "github"
       },
       "original": {
@@ -476,7 +866,23 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1759417375,
+        "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "dc704e6102e76aad573f63b74c742cd96f8f1e6c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -517,11 +923,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1758887862,
-        "narHash": "sha256-7ogD459Ta7RcAVNHAbw849l1Oo3xPO8y9dOQzE4Jh1Y=",
+        "lastModified": 1759387493,
+        "narHash": "sha256-lfurG+rL+0WT3kLk+SYgXF0S+/DSlARAwMgrMzJCBlk=",
         "owner": "iff",
         "repo": "osh-oxy",
-        "rev": "670c5e431912ab96c0fae60bc982830a0f42eb9e",
+        "rev": "e79f39e33912abd5b18ca7f5f1e0d0744d4a09e6",
         "type": "github"
       },
       "original": {
@@ -629,14 +1035,14 @@
         "hypr-contrib": "hypr-contrib",
         "iff-dwm": "iff-dwm",
         "nihilistic-nvim": "nihilistic-nvim",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_5",
         "osh-oxy": "osh-oxy",
         "zsh-syntax-highlighting": "zsh-syntax-highlighting"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1758594771,
@@ -649,6 +1055,29 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rustacean-nvim": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "gen-luarc": "gen-luarc",
+        "git-hooks": "git-hooks",
+        "neorocks": "neorocks",
+        "nixpkgs": "nixpkgs_4",
+        "vimcats": "vimcats"
+      },
+      "locked": {
+        "lastModified": 1759018992,
+        "narHash": "sha256-daJ1BpyPL7DdhLYu2KZw6OmpOylSzCpSwVx6mLjc4Ok=",
+        "owner": "mrcjkb",
+        "repo": "rustaceanvim",
+        "rev": "7c9271934d926969e920f7da932da6ba234b1e5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mrcjkb",
+        "repo": "rustaceanvim",
         "type": "github"
       }
     },
@@ -776,6 +1205,30 @@
         "type": "github"
       }
     },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "neorocks",
+          "neovim-nightly",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1758728421,
+        "narHash": "sha256-ySNJ008muQAds2JemiyrWYbwbG+V7S5wg3ZVKGHSFu8=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "5eda4ee8121f97b218f7cc73f5172098d458f1d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
     "uv2nix": {
       "inputs": {
         "nixpkgs": [
@@ -800,6 +1253,38 @@
       "original": {
         "owner": "pyproject-nix",
         "repo": "uv2nix",
+        "type": "github"
+      }
+    },
+    "vimcats": {
+      "inputs": {
+        "flake-parts": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "nihilistic-nvim",
+          "rustacean-nvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1747309459,
+        "narHash": "sha256-BW1pU7NnW8yWePV0IQOUmcNa13NvV9lOZhfnEdQFBQQ=",
+        "owner": "mrcjkb",
+        "repo": "vimcats",
+        "rev": "60dfc68af5e30cf50475b0a2c64ee2bc8922a727",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mrcjkb",
+        "repo": "vimcats",
         "type": "github"
       }
     },


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/497e2bfa8a45bebe9788e2aa13e766e6a96677cd' (2025-09-26)
  → 'github:nix-community/home-manager/bd92e8ee4a6031ca3dd836c91dc41c13fca1e533' (2025-10-03)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/de79078fd59140067e53cd00ebdf17f96ce27846' (2025-09-22)
  → 'github:hyprwm/contrib/513d71d3f42c05d6a38e215382c5a6ce971bd77d' (2025-09-30)
• Updated input 'nihilistic-nvim':
    'github:iff/nihilistic-nvim/5a0da3d98dd24983db4b49bb81bb3017bf0c776a' (2025-09-29)
  → 'github:iff/nihilistic-nvim/985e56679b005a23515f818d0922e76595d4662c' (2025-09-29)
• Added input 'nihilistic-nvim/rustacean-nvim':
    'github:mrcjkb/rustaceanvim/7c9271934d926969e920f7da932da6ba234b1e5a' (2025-09-28)
• Added input 'nihilistic-nvim/rustacean-nvim/flake-parts':
    'github:hercules-ci/flake-parts/4524271976b625a4a605beefd893f270620fd751' (2025-09-01)
• Added input 'nihilistic-nvim/rustacean-nvim/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/a73b9c743612e4244d865a2fdee11865283c04e6' (2025-08-10)
• Added input 'nihilistic-nvim/rustacean-nvim/gen-luarc':
    'github:mrcjkb/nix-gen-luarc-json/1865b0ebb753ae5324d7381b1fa8c98c04ec7509' (2025-08-16)
• Added input 'nihilistic-nvim/rustacean-nvim/gen-luarc/flake-parts':
    follows 'nihilistic-nvim/rustacean-nvim/flake-parts'
• Added input 'nihilistic-nvim/rustacean-nvim/gen-luarc/git-hooks':
    follows 'nihilistic-nvim/rustacean-nvim/git-hooks'
• Added input 'nihilistic-nvim/rustacean-nvim/gen-luarc/luvit-meta':
    'github:Bilal2453/luvit-meta/ce76f6f6cdc9201523a5875a4471dcfe0186eb60' (2024-01-20)
• Added input 'nihilistic-nvim/rustacean-nvim/gen-luarc/nixpkgs':
    follows 'nihilistic-nvim/rustacean-nvim/nixpkgs'
• Added input 'nihilistic-nvim/rustacean-nvim/git-hooks':
    'github:cachix/git-hooks.nix/54df955a695a84cd47d4a43e08e1feaf90b1fd9b' (2025-09-17)
• Added input 'nihilistic-nvim/rustacean-nvim/git-hooks/flake-compat':
    'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885' (2025-05-12)
• Added input 'nihilistic-nvim/rustacean-nvim/git-hooks/gitignore':
    'github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394' (2024-02-28)
• Added input 'nihilistic-nvim/rustacean-nvim/git-hooks/gitignore/nixpkgs':
    follows 'nihilistic-nvim/rustacean-nvim/git-hooks/nixpkgs'
• Added input 'nihilistic-nvim/rustacean-nvim/git-hooks/nixpkgs':
    follows 'nihilistic-nvim/rustacean-nvim/nixpkgs'
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/fc9288c539d83adae5356b18dea8187ba380dd56' (2025-09-27)
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/flake-compat':
    'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885' (2025-05-12)
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/flake-parts':
    follows 'nihilistic-nvim/rustacean-nvim/flake-parts'
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/git-hooks':
    follows 'nihilistic-nvim/rustacean-nvim/git-hooks'
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/93318bab5ce403a60a694ad1b6219760935553f7' (2025-09-27)
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/flake-compat':
    'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885' (2025-05-12)
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/flake-parts':
    'github:hercules-ci/flake-parts/4524271976b625a4a605beefd893f270620fd751' (2025-09-01)
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/flake-parts/nixpkgs-lib':
    follows 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/nixpkgs'
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/54df955a695a84cd47d4a43e08e1feaf90b1fd9b' (2025-09-17)
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/git-hooks/flake-compat':
    'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885' (2025-05-12)
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/git-hooks/gitignore':
    'github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394' (2024-02-28)
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/git-hooks/gitignore/nixpkgs':
    follows 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/git-hooks/nixpkgs'
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/git-hooks/nixpkgs':
    follows 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/nixpkgs'
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/1a3667d33e247ad35ca250698d63f49a5453d824' (2025-09-16)
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects/flake-parts':
    follows 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/flake-parts'
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects/nixpkgs':
    follows 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/nixpkgs'
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/a0c60e819df1b4d4ae5ac631d48e874fa1cf9b92' (2025-09-26)
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/e57b3b16ad8758fd681511a078f35c416a8cc939' (2025-09-25)
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/treefmt-nix':
    'github:numtide/treefmt-nix/5eda4ee8121f97b218f7cc73f5172098d458f1d1' (2025-09-24)
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/treefmt-nix/nixpkgs':
    follows 'nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/nixpkgs'
• Added input 'nihilistic-nvim/rustacean-nvim/neorocks/nixpkgs':
    follows 'nihilistic-nvim/rustacean-nvim/nixpkgs'
• Added input 'nihilistic-nvim/rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/53614373268559d054c080d070cfc732dbe68ac4' (2025-09-26)
• Added input 'nihilistic-nvim/rustacean-nvim/vimcats':
    'github:mrcjkb/vimcats/60dfc68af5e30cf50475b0a2c64ee2bc8922a727' (2025-05-15)
• Added input 'nihilistic-nvim/rustacean-nvim/vimcats/flake-parts':
    follows 'nihilistic-nvim/rustacean-nvim/flake-parts'
• Added input 'nihilistic-nvim/rustacean-nvim/vimcats/git-hooks':
    follows 'nihilistic-nvim/rustacean-nvim/git-hooks'
• Added input 'nihilistic-nvim/rustacean-nvim/vimcats/nixpkgs':
    follows 'nihilistic-nvim/rustacean-nvim/nixpkgs'
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e57b3b16ad8758fd681511a078f35c416a8cc939' (2025-09-25)
  → 'github:nixos/nixpkgs/dc704e6102e76aad573f63b74c742cd96f8f1e6c' (2025-10-02)
• Updated input 'osh-oxy':
    'github:iff/osh-oxy/670c5e431912ab96c0fae60bc982830a0f42eb9e' (2025-09-26)
  → 'github:iff/osh-oxy/e79f39e33912abd5b18ca7f5f1e0d0744d4a09e6' (2025-10-02)

```

</p></details>

 - Added input [`nihilistic-nvim/rustacean-nvim/git-hooks/gitignore`](https://github.com/hercules-ci/gitignore.nix): [github.com/hercules-ci/gitignore.nix](https://github.com/hercules-ci/gitignore.nix/tree/637db329424fd7e46cf4185293b9cc8c88c95394/)
 - Added input [`nihilistic-nvim/rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [github.com/nixos/nixpkgs](https://github.com/nixos/nixpkgs/tree/53614373268559d054c080d070cfc732dbe68ac4/)
 - Added input `nihilistic-nvim/rustacean-nvim/vimcats/flake-parts`: ``
 - Added input `nihilistic-nvim/rustacean-nvim/gen-luarc/nixpkgs`: ``
 - Added input `nihilistic-nvim/rustacean-nvim/vimcats/git-hooks`: ``
 - Added input [`nihilistic-nvim/rustacean-nvim/flake-parts`](https://github.com/hercules-ci/flake-parts): [github.com/hercules-ci/flake-parts](https://github.com/hercules-ci/flake-parts/tree/4524271976b625a4a605beefd893f270620fd751/)
 - Added input `nihilistic-nvim/rustacean-nvim/neorocks/git-hooks`: ``
 - Added input [`nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [github.com/hercules-ci/hercules-ci-effects](https://github.com/hercules-ci/hercules-ci-effects/tree/1a3667d33e247ad35ca250698d63f49a5453d824/)
 - Added input [`nihilistic-nvim/rustacean-nvim/gen-luarc/luvit-meta`](https://github.com/Bilal2453/luvit-meta): [github.com/Bilal2453/luvit-meta](https://github.com/Bilal2453/luvit-meta/tree/ce76f6f6cdc9201523a5875a4471dcfe0186eb60/)
 - Added input [`nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [github.com/NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/e57b3b16ad8758fd681511a078f35c416a8cc939/)
 - Added input `nihilistic-nvim/rustacean-nvim/neorocks/nixpkgs`: ``
 - Added input [`nihilistic-nvim/rustacean-nvim/neorocks/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/9100a0f413b0c601e0533d1d94ffd501ce2e7885/)
 - Added input [`nihilistic-nvim/rustacean-nvim/git-hooks/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/9100a0f413b0c601e0533d1d94ffd501ce2e7885/)
 - Added input `nihilistic-nvim/rustacean-nvim/git-hooks/nixpkgs`: ``
 - Added input [`nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/9100a0f413b0c601e0533d1d94ffd501ce2e7885/)
 - Added input `nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/treefmt-nix/nixpkgs`: ``
 - Added input `nihilistic-nvim/rustacean-nvim/git-hooks/gitignore/nixpkgs`: ``
 - Added input [`nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [github.com/nix-community/neovim-nightly-overlay](https://github.com/nix-community/neovim-nightly-overlay/tree/93318bab5ce403a60a694ad1b6219760935553f7/)
 - Added input `nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/flake-parts/nixpkgs-lib`: ``
 - Added input `nihilistic-nvim/rustacean-nvim/neorocks/flake-parts`: ``
 - Added input [`nihilistic-nvim/rustacean-nvim/git-hooks`](https://github.com/cachix/git-hooks.nix): [github.com/cachix/git-hooks.nix](https://github.com/cachix/git-hooks.nix/tree/54df955a695a84cd47d4a43e08e1feaf90b1fd9b/)
 - Added input [`nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [github.com/neovim/neovim](https://github.com/neovim/neovim/tree/a0c60e819df1b4d4ae5ac631d48e874fa1cf9b92/)
 - Updated input [`osh-oxy`](https://github.com/iff/osh-oxy): [`670c5e43` ➡️ `e79f39e3`](https://github.com/iff/osh-oxy/compare/670c5e431912ab96c0fae60bc982830a0f42eb9e...e79f39e33912abd5b18ca7f5f1e0d0744d4a09e6) <sub>(2025-09-26 to 2025-10-02)</sub>
 - Added input `nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/git-hooks/gitignore/nixpkgs`: ``
 - Added input `nihilistic-nvim/rustacean-nvim/gen-luarc/flake-parts`: ``
 - Added input [`nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/flake-parts`](https://github.com/hercules-ci/flake-parts): [github.com/hercules-ci/flake-parts](https://github.com/hercules-ci/flake-parts/tree/4524271976b625a4a605beefd893f270620fd751/)
 - Added input [`nihilistic-nvim/rustacean-nvim/vimcats`](https://github.com/mrcjkb/vimcats): [github.com/mrcjkb/vimcats](https://github.com/mrcjkb/vimcats/tree/60dfc68af5e30cf50475b0a2c64ee2bc8922a727/)
 - Added input [`nihilistic-nvim/rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [github.com/mrcjkb/rustaceanvim](https://github.com/mrcjkb/rustaceanvim/tree/7c9271934d926969e920f7da932da6ba234b1e5a/)
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`de79078f` ➡️ `513d71d3`](https://github.com/hyprwm/contrib/compare/de79078fd59140067e53cd00ebdf17f96ce27846...513d71d3f42c05d6a38e215382c5a6ce971bd77d) <sub>(2025-09-22 to 2025-09-30)</sub>
 - Added input `nihilistic-nvim/rustacean-nvim/gen-luarc/git-hooks`: ``
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`497e2bfa` ➡️ `bd92e8ee`](https://github.com/nix-community/home-manager/compare/497e2bfa8a45bebe9788e2aa13e766e6a96677cd...bd92e8ee4a6031ca3dd836c91dc41c13fca1e533) <sub>(2025-09-26 to 2025-10-03)</sub>
 - Added input `nihilistic-nvim/rustacean-nvim/vimcats/nixpkgs`: ``
 - Added input `nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects/nixpkgs`: ``
 - Added input [`nihilistic-nvim/rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [github.com/nvim-neorocks/neorocks](https://github.com/nvim-neorocks/neorocks/tree/fc9288c539d83adae5356b18dea8187ba380dd56/)
 - Added input [`nihilistic-nvim/rustacean-nvim/flake-parts/nixpkgs-lib`](https://github.com/nix-community/nixpkgs.lib): [github.com/nix-community/nixpkgs.lib](https://github.com/nix-community/nixpkgs.lib/tree/a73b9c743612e4244d865a2fdee11865283c04e6/)
 - Added input `nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/git-hooks/nixpkgs`: ``
 - Updated input [`nihilistic-nvim`](https://github.com/iff/nihilistic-nvim): [`5a0da3d9` ➡️ `985e5667`](https://github.com/iff/nihilistic-nvim/compare/5a0da3d98dd24983db4b49bb81bb3017bf0c776a...985e56679b005a23515f818d0922e76595d4662c) <sub>(2025-09-29 to 2025-09-29)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`e57b3b16` ➡️ `dc704e61`](https://github.com/nixos/nixpkgs/compare/e57b3b16ad8758fd681511a078f35c416a8cc939...dc704e6102e76aad573f63b74c742cd96f8f1e6c) <sub>(2025-09-25 to 2025-10-02)</sub>
 - Added input `nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects/flake-parts`: ``
 - Added input [`nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/git-hooks/gitignore`](https://github.com/hercules-ci/gitignore.nix): [github.com/hercules-ci/gitignore.nix](https://github.com/hercules-ci/gitignore.nix/tree/637db329424fd7e46cf4185293b9cc8c88c95394/)
 - Added input [`nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/treefmt-nix`](https://github.com/numtide/treefmt-nix): [github.com/numtide/treefmt-nix](https://github.com/numtide/treefmt-nix/tree/5eda4ee8121f97b218f7cc73f5172098d458f1d1/)
 - Added input [`nihilistic-nvim/rustacean-nvim/gen-luarc`](https://github.com/mrcjkb/nix-gen-luarc-json): [github.com/mrcjkb/nix-gen-luarc-json](https://github.com/mrcjkb/nix-gen-luarc-json/tree/1865b0ebb753ae5324d7381b1fa8c98c04ec7509/)
 - Added input [`nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/git-hooks/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/9100a0f413b0c601e0533d1d94ffd501ce2e7885/)
 - Added input [`nihilistic-nvim/rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [github.com/cachix/git-hooks.nix](https://github.com/cachix/git-hooks.nix/tree/54df955a695a84cd47d4a43e08e1feaf90b1fd9b/)