### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         "telescope-ui-select-nvim": "telescope-ui-select-nvim"
       },
       "locked": {
-        "lastModified": 1774941798,
-        "narHash": "sha256-JfnQKfCvI4mhFDN5FNx1RxzLuszFeXC5U1rcCKbyEKQ=",
+        "lastModified": 1775289524,
+        "narHash": "sha256-dvQK4bhdx4dQjQdGVieDBLe6LaJlhvZCUzA1CUQjQek=",
         "owner": "iff",
         "repo": "nihilistic-nvim",
-        "rev": "3f2d2b94fbd583c54872a172c46d68afeb62d42b",
+        "rev": "070036b12543163bb6175956f27b628a4d8cf017",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774626137,
-        "narHash": "sha256-1WelwA45Xm4glTG8R9IX9jYeFKDG2HbR79jAauLezUE=",
+        "lastModified": 1775247674,
+        "narHash": "sha256-MCaiC3iWarAsmu8KJXgJHb1H8lf+BD9gymvxkbmNVdc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9df3a639007cfe0d074433f7fc225ea94f877d08",
+        "rev": "03bdcf84f092956943dcf9ef164481e463512716",
         "type": "github"
       },
       "original": {
@@ -197,11 +197,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1773993211,
-        "narHash": "sha256-4J6vEtf7dIw3pZ/xM/dU7ECTmr8AsIIUQJba1B8wp5k=",
+        "lastModified": 1774778246,
+        "narHash": "sha256-OX9Oba3/cHq1jMS1/ItCdxNuRBH3291Lg727nHOzYnc=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "43c012d21d9314c585b97ac4f34752f6de93dc8f",
+        "rev": "ca3c381df6018e6c400ceac994066427c98fe323",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1773075148,
-        "narHash": "sha256-EA4OzEpGKr/KFjpVGckhl8nAycTUvmVQddSaUS5Vo7M=",
+        "lastModified": 1775222109,
+        "narHash": "sha256-CMYZuRh8n0PZJpsCRwclnNDOZrDGXA06/FTGZ1PQyGQ=",
         "owner": "dkuettel",
         "repo": "ltstatus",
-        "rev": "a6629c22eb372ee8f675dafca365b14adb811b26",
+        "rev": "98464ad09926c646ef004aa746295b37c7cb4bf0",
         "type": "github"
       },
       "original": {
@@ -304,11 +304,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1773075291,
-        "narHash": "sha256-RsgQ+HJBbACr/Yduvn5XOseppRwfY/rtTfqFKXCq5Hs=",
+        "lastModified": 1775222192,
+        "narHash": "sha256-70M+u5/kPvtdBqHbI0M6wSzPvJy/KyJz79PV02QVAr0=",
         "owner": "dkuettel",
         "repo": "nd",
-        "rev": "05be0e2e2d6636d992807ac3d7c4713583a531a8",
+        "rev": "37f18c1712e99e39252e9cc40016a037cd43adbf",
         "type": "github"
       },
       "original": {
@@ -388,11 +388,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1772822230,
-        "narHash": "sha256-yf3iYLGbGVlIthlQIk5/4/EQDZNNEmuqKZkQssMljuw=",
+        "lastModified": 1775002709,
+        "narHash": "sha256-d3Yx83vSrN+2z/loBh4mJpyRqr9aAJqlke4TkpFmRJA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "71caefce12ba78d84fe618cf61644dce01cf3a96",
+        "rev": "bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e",
         "type": "github"
       },
       "original": {
@@ -404,11 +404,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1772822230,
-        "narHash": "sha256-yf3iYLGbGVlIthlQIk5/4/EQDZNNEmuqKZkQssMljuw=",
+        "lastModified": 1775002709,
+        "narHash": "sha256-d3Yx83vSrN+2z/loBh4mJpyRqr9aAJqlke4TkpFmRJA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "71caefce12ba78d84fe618cf61644dce01cf3a96",
+        "rev": "bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e",
         "type": "github"
       },
       "original": {
@@ -436,11 +436,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1774273680,
-        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "lastModified": 1775126147,
+        "narHash": "sha256-J0dZU4atgcfo4QvM9D92uQ0Oe1eLTxBVXjJzdEMQpD0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "rev": "8d8c1fa5b412c223ffa47410867813290cdedfef",
         "type": "github"
       },
       "original": {
@@ -542,11 +542,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772555609,
-        "narHash": "sha256-3BA3HnUvJSbHJAlJj6XSy0Jmu7RyP2gyB/0fL7XuEDo=",
+        "lastModified": 1773870109,
+        "narHash": "sha256-ZoTdqZP03DcdoyxvpFHCAek4bkPUTUPUF3oCCgc3dP4=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "c37f66a953535c394244888598947679af231863",
+        "rev": "b6e74f433b02fa4b8a7965ee24680f4867e2926f",
         "type": "github"
       },
       "original": {
@@ -595,11 +595,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772865871,
-        "narHash": "sha256-/ZTSg97aouL0SlPHaokA4r3iuH9QzHVuWPACD2CUCFY=",
+        "lastModified": 1775197701,
+        "narHash": "sha256-W9dcvnvbpZZexKVnDp/8NiNXqy2gnq1FWCD142/Skp8=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "e537db02e72d553cea470976b9733581bcf5b3ed",
+        "rev": "946e5fb82c3443940c45e5a61686d173e2e21155",
         "type": "github"
       },
       "original": {
@@ -844,11 +844,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773039484,
-        "narHash": "sha256-+boo33KYkJDw9KItpeEXXv8+65f7hHv/earxpcyzQ0I=",
+        "lastModified": 1775195476,
+        "narHash": "sha256-uaPmLBiYfd6dpTJD8SI6+8Cg0ciUpHc5uN5EbFmd6SE=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "b68be7cfeacbed9a3fa38a2b5adc0cfb81d9bb1f",
+        "rev": "7fac30f496a7d9853e8c301a8edbfc35af50d418",
         "type": "github"
       },
       "original": {

--- a/system/nixos/hosts/kharbranth/home.nix
+++ b/system/nixos/hosts/kharbranth/home.nix
@@ -36,7 +36,6 @@ in
     #
     switch
     #
-    cudaPackages.cuda_nvcc
     cudaPackages.cudatoolkit
     # games
     beyond-all-reason


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/9df3a639007cfe0d074433f7fc225ea94f877d08' (2026-03-27)
  → 'github:nix-community/home-manager/03bdcf84f092956943dcf9ef164481e463512716' (2026-04-03)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/43c012d21d9314c585b97ac4f34752f6de93dc8f' (2026-03-20)
  → 'github:hyprwm/contrib/ca3c381df6018e6c400ceac994066427c98fe323' (2026-03-29)
• Updated input 'ltstatus':
    'github:dkuettel/ltstatus/a6629c22eb372ee8f675dafca365b14adb811b26' (2026-03-09)
  → 'github:dkuettel/ltstatus/98464ad09926c646ef004aa746295b37c7cb4bf0' (2026-04-03)
• Updated input 'ltstatus/nixpkgs':
    'github:NixOS/nixpkgs/71caefce12ba78d84fe618cf61644dce01cf3a96' (2026-03-06)
  → 'github:NixOS/nixpkgs/bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e' (2026-04-01)
• Updated input 'ltstatus/pyproject-build-systems':
    'github:pyproject-nix/build-system-pkgs/c37f66a953535c394244888598947679af231863' (2026-03-03)
  → 'github:pyproject-nix/build-system-pkgs/b6e74f433b02fa4b8a7965ee24680f4867e2926f' (2026-03-18)
• Updated input 'ltstatus/pyproject-nix':
    'github:pyproject-nix/pyproject.nix/e537db02e72d553cea470976b9733581bcf5b3ed' (2026-03-07)
  → 'github:pyproject-nix/pyproject.nix/946e5fb82c3443940c45e5a61686d173e2e21155' (2026-04-03)
• Updated input 'ltstatus/uv2nix':
    'github:pyproject-nix/uv2nix/b68be7cfeacbed9a3fa38a2b5adc0cfb81d9bb1f' (2026-03-09)
  → 'github:pyproject-nix/uv2nix/7fac30f496a7d9853e8c301a8edbfc35af50d418' (2026-04-03)
• Updated input 'nd':
    'github:dkuettel/nd/05be0e2e2d6636d992807ac3d7c4713583a531a8' (2026-03-09)
  → 'github:dkuettel/nd/37f18c1712e99e39252e9cc40016a037cd43adbf' (2026-04-03)
• Updated input 'nd/nixpkgs':
    'github:NixOS/nixpkgs/71caefce12ba78d84fe618cf61644dce01cf3a96' (2026-03-06)
  → 'github:NixOS/nixpkgs/bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e' (2026-04-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/fdc7b8f7b30fdbedec91b71ed82f36e1637483ed' (2026-03-23)
  → 'github:nixos/nixpkgs/8d8c1fa5b412c223ffa47410867813290cdedfef' (2026-04-02)

```

</p></details>

 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`9df3a639` ➡️ `03bdcf84`](https://github.com/nix-community/home-manager/compare/9df3a639007cfe0d074433f7fc225ea94f877d08...03bdcf84f092956943dcf9ef164481e463512716) <sub>(2026-03-27 to 2026-04-03)<sub/>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`43c012d2` ➡️ `ca3c381d`](https://github.com/hyprwm/contrib/compare/43c012d21d9314c585b97ac4f34752f6de93dc8f...ca3c381df6018e6c400ceac994066427c98fe323) <sub>(2026-03-20 to 2026-03-29)<sub/>
 - Updated input [`ltstatus`](https://github.com/dkuettel/ltstatus): [`a6629c22` ➡️ `98464ad0`](https://github.com/dkuettel/ltstatus/compare/a6629c22eb372ee8f675dafca365b14adb811b26...98464ad09926c646ef004aa746295b37c7cb4bf0) <sub>(2026-03-09 to 2026-04-03)<sub/>
 - Updated input [`ltstatus/nixpkgs`](https://github.com/NixOS/nixpkgs): [`71caefce` ➡️ `bcd464cc`](https://github.com/NixOS/nixpkgs/compare/71caefce12ba78d84fe618cf61644dce01cf3a96...bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e) <sub>(2026-03-06 to 2026-04-01)<sub/>
 - Updated input [`ltstatus/pyproject-build-systems`](https://github.com/pyproject-nix/build-system-pkgs): [`c37f66a9` ➡️ `b6e74f43`](https://github.com/pyproject-nix/build-system-pkgs/compare/c37f66a953535c394244888598947679af231863...b6e74f433b02fa4b8a7965ee24680f4867e2926f) <sub>(2026-03-03 to 2026-03-18)<sub/>
 - Updated input [`ltstatus/pyproject-nix`](https://github.com/pyproject-nix/pyproject.nix): [`e537db02` ➡️ `946e5fb8`](https://github.com/pyproject-nix/pyproject.nix/compare/e537db02e72d553cea470976b9733581bcf5b3ed...946e5fb82c3443940c45e5a61686d173e2e21155) <sub>(2026-03-07 to 2026-04-03)<sub/>
 - Updated input [`ltstatus/uv2nix`](https://github.com/pyproject-nix/uv2nix): [`b68be7cf` ➡️ `7fac30f4`](https://github.com/pyproject-nix/uv2nix/compare/b68be7cfeacbed9a3fa38a2b5adc0cfb81d9bb1f...7fac30f496a7d9853e8c301a8edbfc35af50d418) <sub>(2026-03-09 to 2026-04-03)<sub/>
 - Updated input [`nd`](https://github.com/dkuettel/nd): [`05be0e2e` ➡️ `37f18c17`](https://github.com/dkuettel/nd/compare/05be0e2e2d6636d992807ac3d7c4713583a531a8...37f18c1712e99e39252e9cc40016a037cd43adbf) <sub>(2026-03-09 to 2026-04-03)<sub/>
 - Updated input [`nd/nixpkgs`](https://github.com/NixOS/nixpkgs): [`71caefce` ➡️ `bcd464cc`](https://github.com/NixOS/nixpkgs/compare/71caefce12ba78d84fe618cf61644dce01cf3a96...bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e) <sub>(2026-03-06 to 2026-04-01)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`fdc7b8f7` ➡️ `8d8c1fa5`](https://github.com/nixos/nixpkgs/compare/fdc7b8f7b30fdbedec91b71ed82f36e1637483ed...8d8c1fa5b412c223ffa47410867813290cdedfef) <sub>(2026-03-23 to 2026-04-02)<sub/>