### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775781825,
-        "narHash": "sha256-L5yKTpR+alrZU2XYYvIxCeCP4LBHU5jhwSj7H1VAavg=",
+        "lastModified": 1776454077,
+        "narHash": "sha256-7zSUFWsU0+jlD7WB3YAxQ84Z/iJurA5hKPm8EfEyGJk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e35c39fca04fee829cecdf839a50eb9b54d8a701",
+        "rev": "565e5349208fe7d0831ef959103c9bafbeac0681",
         "type": "github"
       },
       "original": {
@@ -197,11 +197,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1774778246,
-        "narHash": "sha256-OX9Oba3/cHq1jMS1/ItCdxNuRBH3291Lg727nHOzYnc=",
+        "lastModified": 1776426061,
+        "narHash": "sha256-3rROoGl8xBsIOM+5m+qZS4GJnsdQPAH3NJJe1OUfJ5o=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "ca3c381df6018e6c400ceac994066427c98fe323",
+        "rev": "1f71628d86a7701fd5ba0f8aeabe15376f4c6afc",
         "type": "github"
       },
       "original": {
@@ -357,11 +357,11 @@
         "telescope-ui-select-nvim": "telescope-ui-select-nvim"
       },
       "locked": {
-        "lastModified": 1776061251,
-        "narHash": "sha256-+yyRSKNREgBjmvH+BfwzgpkadExcs4Lp3iRjAYsJOAo=",
+        "lastModified": 1776323548,
+        "narHash": "sha256-LgheGXxGmrHp21RwVG2vRcT5IKF+0HRcqB329GWHdMA=",
         "owner": "iff",
         "repo": "nihilistic-nvim",
-        "rev": "e5d8ec38b3b9c162c284795dd3e235d779869d9c",
+        "rev": "dc862280d16af940f2d743a958d51d7abdb25fd8",
         "type": "github"
       },
       "original": {
@@ -436,11 +436,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1775793324,
-        "narHash": "sha256-omax7atcZbol+6HJ2RLpP+ZCFcPa5bZ65Hn71RufeWQ=",
+        "lastModified": 1776255774,
+        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9d29d5f667d7467f98efc31881e824fa586c927e",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
         "type": "github"
       },
       "original": {
@@ -491,11 +491,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1775740867,
-        "narHash": "sha256-Jmlg94L6Aa0CQpzIeula4rhQWntBDxKFNC7b5oC2KXs=",
+        "lastModified": 1776339366,
+        "narHash": "sha256-KxAVXDVZ2ddGmUgaPtHB+A9h/Sbq9rznYS/X/+gZZyw=",
         "owner": "iff",
         "repo": "osh-oxy",
-        "rev": "0cec86273397fdfbbe41e3d26bcce269b026689a",
+        "rev": "b38dc57be46b3e3d770dcd9a6832213c3c8bf347",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/e35c39fca04fee829cecdf839a50eb9b54d8a701' (2026-04-10)
  → 'github:nix-community/home-manager/565e5349208fe7d0831ef959103c9bafbeac0681' (2026-04-17)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/ca3c381df6018e6c400ceac994066427c98fe323' (2026-03-29)
  → 'github:hyprwm/contrib/1f71628d86a7701fd5ba0f8aeabe15376f4c6afc' (2026-04-17)
• Updated input 'nihilistic-nvim':
    'github:iff/nihilistic-nvim/e5d8ec38b3b9c162c284795dd3e235d779869d9c' (2026-04-13)
  → 'github:iff/nihilistic-nvim/dc862280d16af940f2d743a958d51d7abdb25fd8' (2026-04-16)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/9d29d5f667d7467f98efc31881e824fa586c927e' (2026-04-10)
  → 'github:nixos/nixpkgs/566acc07c54dc807f91625bb286cb9b321b5f42a' (2026-04-15)
• Updated input 'osh-oxy':
    'github:iff/osh-oxy/0cec86273397fdfbbe41e3d26bcce269b026689a' (2026-04-09)
  → 'github:iff/osh-oxy/b38dc57be46b3e3d770dcd9a6832213c3c8bf347' (2026-04-16)

```

</p></details>

 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`e35c39fc` ➡️ `565e5349`](https://github.com/nix-community/home-manager/compare/e35c39fca04fee829cecdf839a50eb9b54d8a701...565e5349208fe7d0831ef959103c9bafbeac0681) <sub>(2026-04-10 to 2026-04-17)<sub/>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`ca3c381d` ➡️ `1f71628d`](https://github.com/hyprwm/contrib/compare/ca3c381df6018e6c400ceac994066427c98fe323...1f71628d86a7701fd5ba0f8aeabe15376f4c6afc) <sub>(2026-03-29 to 2026-04-17)<sub/>
 - Updated input [`nihilistic-nvim`](https://github.com/iff/nihilistic-nvim): [`e5d8ec38` ➡️ `dc862280`](https://github.com/iff/nihilistic-nvim/compare/e5d8ec38b3b9c162c284795dd3e235d779869d9c...dc862280d16af940f2d743a958d51d7abdb25fd8) <sub>(2026-04-13 to 2026-04-16)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`9d29d5f6` ➡️ `566acc07`](https://github.com/nixos/nixpkgs/compare/9d29d5f667d7467f98efc31881e824fa586c927e...566acc07c54dc807f91625bb286cb9b321b5f42a) <sub>(2026-04-10 to 2026-04-15)<sub/>
 - Updated input [`osh-oxy`](https://github.com/iff/osh-oxy): [`0cec8627` ➡️ `b38dc57b`](https://github.com/iff/osh-oxy/compare/0cec86273397fdfbbe41e3d26bcce269b026689a...b38dc57be46b3e3d770dcd9a6832213c3c8bf347) <sub>(2026-04-09 to 2026-04-16)<sub/>