### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776454077,
-        "narHash": "sha256-7zSUFWsU0+jlD7WB3YAxQ84Z/iJurA5hKPm8EfEyGJk=",
+        "lastModified": 1777054018,
+        "narHash": "sha256-tTNS7V6xN/LX1KZ0TrdOnj375ZrsUlLoce4qxZwDN9U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "565e5349208fe7d0831ef959103c9bafbeac0681",
+        "rev": "ffbd94a1c9d7d3e1258e51c084ab2109da04f2b1",
         "type": "github"
       },
       "original": {
@@ -357,11 +357,11 @@
         "telescope-ui-select-nvim": "telescope-ui-select-nvim"
       },
       "locked": {
-        "lastModified": 1776323548,
-        "narHash": "sha256-LgheGXxGmrHp21RwVG2vRcT5IKF+0HRcqB329GWHdMA=",
+        "lastModified": 1776667570,
+        "narHash": "sha256-pzA+Os4pwlZCpT1zKZ8RblNS2GBZhn3nk72Mcw6c4XM=",
         "owner": "iff",
         "repo": "nihilistic-nvim",
-        "rev": "dc862280d16af940f2d743a958d51d7abdb25fd8",
+        "rev": "821c0e780df0fae9847d7430aa503de37fb6ed6f",
         "type": "github"
       },
       "original": {
@@ -436,11 +436,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1776255774,
-        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
         "type": "github"
       },
       "original": {
@@ -469,11 +469,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1776021290,
-        "narHash": "sha256-y7OgmBs1baqNbLfI80CmGSJOgZi0xcOsJOhyZmsKJP8=",
+        "lastModified": 1776329745,
+        "narHash": "sha256-RZs2wqVgGy6TNBWZifoj+58gIpNC0kZtt5MiNPQ38+U=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "8a9378a822719346a0288fa004dab302ca3c0a8f",
+        "rev": "4b7fbaa239c5db6b36f424a4521ca9f1a401be33",
         "type": "github"
       },
       "original": {
@@ -803,11 +803,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1775811923,
-        "narHash": "sha256-dncm8Cd4TUMhO+uaRvRsPZngDye3WR16FryuYp0lbMI=",
+        "lastModified": 1776591070,
+        "narHash": "sha256-xU/lozREXuXkjBq8L94sLwyEE6f7k8Q3y0BkjPssB1Y=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "f7c673b8e46e8f233ff581d3624a517d33a7e264",
+        "rev": "028d9a0695a0cc4cfa893889f8c408ed7ccc8adc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/565e5349208fe7d0831ef959103c9bafbeac0681' (2026-04-17)
  → 'github:nix-community/home-manager/ffbd94a1c9d7d3e1258e51c084ab2109da04f2b1' (2026-04-24)
• Updated input 'nihilistic-nvim':
    'github:iff/nihilistic-nvim/dc862280d16af940f2d743a958d51d7abdb25fd8' (2026-04-16)
  → 'github:iff/nihilistic-nvim/821c0e780df0fae9847d7430aa503de37fb6ed6f' (2026-04-20)
• Updated input 'nihilistic-nvim/nvim-lspconfig':
    'github:neovim/nvim-lspconfig/8a9378a822719346a0288fa004dab302ca3c0a8f' (2026-04-12)
  → 'github:neovim/nvim-lspconfig/4b7fbaa239c5db6b36f424a4521ca9f1a401be33' (2026-04-16)
• Updated input 'nihilistic-nvim/telescope-nvim':
    'github:nvim-telescope/telescope.nvim/f7c673b8e46e8f233ff581d3624a517d33a7e264' (2026-04-10)
  → 'github:nvim-telescope/telescope.nvim/028d9a0695a0cc4cfa893889f8c408ed7ccc8adc' (2026-04-19)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/566acc07c54dc807f91625bb286cb9b321b5f42a' (2026-04-15)
  → 'github:nixos/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30' (2026-04-23)

```

</p></details>

 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`565e5349` ➡️ `ffbd94a1`](https://github.com/nix-community/home-manager/compare/565e5349208fe7d0831ef959103c9bafbeac0681...ffbd94a1c9d7d3e1258e51c084ab2109da04f2b1) <sub>(2026-04-17 to 2026-04-24)<sub/>
 - Updated input [`nihilistic-nvim`](https://github.com/iff/nihilistic-nvim): [`dc862280` ➡️ `821c0e78`](https://github.com/iff/nihilistic-nvim/compare/dc862280d16af940f2d743a958d51d7abdb25fd8...821c0e780df0fae9847d7430aa503de37fb6ed6f) <sub>(2026-04-16 to 2026-04-20)<sub/>
 - Updated input [`nihilistic-nvim/nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`8a9378a8` ➡️ `4b7fbaa2`](https://github.com/neovim/nvim-lspconfig/compare/8a9378a822719346a0288fa004dab302ca3c0a8f...4b7fbaa239c5db6b36f424a4521ca9f1a401be33) <sub>(2026-04-12 to 2026-04-16)<sub/>
 - Updated input [`nihilistic-nvim/telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`f7c673b8` ➡️ `028d9a06`](https://github.com/nvim-telescope/telescope.nvim/compare/f7c673b8e46e8f233ff581d3624a517d33a7e264...028d9a0695a0cc4cfa893889f8c408ed7ccc8adc) <sub>(2026-04-10 to 2026-04-19)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`566acc07` ➡️ `01fbdeef`](https://github.com/nixos/nixpkgs/compare/566acc07c54dc807f91625bb286cb9b321b5f42a...01fbdeef22b76df85ea168fbfe1bfd9e63681b30) <sub>(2026-04-15 to 2026-04-23)<sub/>