### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -143,11 +143,11 @@
     "funky-formatter-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1775222241,
-        "narHash": "sha256-aEpTU0uTCdih0rFwNmnzTCUzDK2mHiQrwtKwVp/4YIo=",
+        "lastModified": 1777811754,
+        "narHash": "sha256-4qAmNXzbQhD9SCVYQ2SGrmR9QwynhKnTwGAxkFXYPao=",
         "owner": "dkuettel",
         "repo": "funky-formatter.nvim",
-        "rev": "9307a67bccb0fc17698211ae05f1f30bf568038b",
+        "rev": "57bcb3b15af93b171b09cf84d84219fbc452543a",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777659959,
-        "narHash": "sha256-ax3229dUvNuwTQwo2o68kOQ24dvOlJ/BrVYY4miD1bI=",
+        "lastModified": 1778248595,
+        "narHash": "sha256-dhFgEjoeJMYN/7OY6xfxS799YB4IjbbYXTjyGIJyLpc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5c1b74905c7261e8280dcda3623dbe677a1bc158",
+        "rev": "fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1775683260,
-        "narHash": "sha256-ExSaSpyav8kDitVuSW5cq0qEmBupXEn5tQnSg2c2NQU=",
+        "lastModified": 1777811630,
+        "narHash": "sha256-CJBlOKf2RSwIw2WuiCDoauKZkiIza/RrXKxjPSZu8N4=",
         "owner": "dkuettel",
         "repo": "ltstatus",
-        "rev": "b643f7aedd7163be8be4b7abd313581d32a24d22",
+        "rev": "416fba2d6030977f6f11f60c18cfe06a1ff08a57",
         "type": "github"
       },
       "original": {
@@ -269,11 +269,11 @@
     "lualine-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1775957658,
-        "narHash": "sha256-PHunrG0yd3pDw3c1S9w1AXQx5/1nT68M+mjxT53enmM=",
+        "lastModified": 1777365207,
+        "narHash": "sha256-5+JKZD4w80QZxnFv+1OxkFVety8fgmcGVOuxfYouxhI=",
         "owner": "nvim-lualine",
         "repo": "lualine.nvim",
-        "rev": "a905eeebc4e63fdc48b5135d3bf8aea5618fb21c",
+        "rev": "131a558e13f9f28b15cd235557150ccb23f89286",
         "type": "github"
       },
       "original": {
@@ -304,11 +304,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1775222192,
-        "narHash": "sha256-70M+u5/kPvtdBqHbI0M6wSzPvJy/KyJz79PV02QVAr0=",
+        "lastModified": 1777811709,
+        "narHash": "sha256-5jVac2kyl7HKQLDk/Ijnb91C5zLRJuDxNoz+ouMQSz4=",
         "owner": "dkuettel",
         "repo": "nd",
-        "rev": "37f18c1712e99e39252e9cc40016a037cd43adbf",
+        "rev": "e5c0a6a37b6c7105a742fc612d1e526b18bc8141",
         "type": "github"
       },
       "original": {
@@ -321,11 +321,11 @@
     "nightfox-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1739121671,
-        "narHash": "sha256-HoZEwncrUnypWxyB+XR0UQDv+tNu1/NbvimxYGb7qu8=",
+        "lastModified": 1777822298,
+        "narHash": "sha256-xSnMYGilRjNHh1G1eOghl8Dr93HsCe3WHHAkchCyW+E=",
         "owner": "EdenEast",
         "repo": "nightfox.nvim",
-        "rev": "ba47d4b4c5ec308718641ba7402c143836f35aa9",
+        "rev": "26b61b1f856ec37cae3cb64f5690adb955f246a1",
         "type": "github"
       },
       "original": {
@@ -357,11 +357,11 @@
         "telescope-ui-select-nvim": "telescope-ui-select-nvim"
       },
       "locked": {
-        "lastModified": 1777308820,
-        "narHash": "sha256-7C1m+ESZbvM4HTJuhq+aPz3/xDEt9x/Pnbg+x4kUiyY=",
+        "lastModified": 1777868986,
+        "narHash": "sha256-9VeZbQ6GxJfDrd6vZcPCa0bQmV2uoYRVVccOs3NA9MY=",
         "owner": "iff",
         "repo": "nihilistic-nvim",
-        "rev": "117b0391ba030ac9481af7481f3fef80eddc07ec",
+        "rev": "10602ea28dd23772b4be33722be2619536d16650",
         "type": "github"
       },
       "original": {
@@ -388,11 +388,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1775002709,
-        "narHash": "sha256-d3Yx83vSrN+2z/loBh4mJpyRqr9aAJqlke4TkpFmRJA=",
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
         "type": "github"
       },
       "original": {
@@ -404,11 +404,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1775002709,
-        "narHash": "sha256-d3Yx83vSrN+2z/loBh4mJpyRqr9aAJqlke4TkpFmRJA=",
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1775002709,
-        "narHash": "sha256-d3Yx83vSrN+2z/loBh4mJpyRqr9aAJqlke4TkpFmRJA=",
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
         "type": "github"
       },
       "original": {
@@ -436,11 +436,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1777548390,
-        "narHash": "sha256-WacE23EbHTsBKvr8cu+1DFNbP6Rh1brHUH5SDUI0NQI=",
+        "lastModified": 1778124196,
+        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7aaa00e7cc9be6c316cb5f6617bd740dd435c59d",
+        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
         "type": "github"
       },
       "original": {
@@ -469,11 +469,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1777198644,
-        "narHash": "sha256-w21MFUH+44m3uJKm0LrlXe4etp6TgE6P8tJvy4q+Goc=",
+        "lastModified": 1777577415,
+        "narHash": "sha256-Iox/cnIsgPXB6KYhuy5j2zYHudMCcdQRKWX9DTlIcoo=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "21db1fd40cbcbf1524ae154ab8f394fdf085749a",
+        "rev": "31026a13eefb20681124706a79fc1df6bf11ab27",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "uv2nix": "uv2nix_2"
       },
       "locked": {
-        "lastModified": 1775590987,
-        "narHash": "sha256-0H8adz3b0WSW7W1NG+mfJb69/Ag4xK/XCNjqzaP3LsM=",
+        "lastModified": 1777811797,
+        "narHash": "sha256-/k5sEkWcsYRmbxLFjFcmIvnuusSuISx32HH2u8dWudw=",
         "owner": "dkuettel",
         "repo": "ptags.nvim",
-        "rev": "b737c85e0cd5d3f7d1867508015edace194c4717",
+        "rev": "0cde99f2c395968bceea9b0d871b84da600b5f2a",
         "type": "github"
       },
       "original": {
@@ -542,11 +542,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773870109,
-        "narHash": "sha256-ZoTdqZP03DcdoyxvpFHCAek4bkPUTUPUF3oCCgc3dP4=",
+        "lastModified": 1776659114,
+        "narHash": "sha256-qapCOQmR++yZSY43dzrp3wCrkOTLpod+ONtJWBk6iKU=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "b6e74f433b02fa4b8a7965ee24680f4867e2926f",
+        "rev": "ffaa2161dd5d63e0e94591f86b54fc239660fb2e",
         "type": "github"
       },
       "original": {
@@ -574,11 +574,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773870109,
-        "narHash": "sha256-ZoTdqZP03DcdoyxvpFHCAek4bkPUTUPUF3oCCgc3dP4=",
+        "lastModified": 1776659114,
+        "narHash": "sha256-qapCOQmR++yZSY43dzrp3wCrkOTLpod+ONtJWBk6iKU=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "b6e74f433b02fa4b8a7965ee24680f4867e2926f",
+        "rev": "ffaa2161dd5d63e0e94591f86b54fc239660fb2e",
         "type": "github"
       },
       "original": {
@@ -595,11 +595,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775197701,
-        "narHash": "sha256-W9dcvnvbpZZexKVnDp/8NiNXqy2gnq1FWCD142/Skp8=",
+        "lastModified": 1776715674,
+        "narHash": "sha256-Gs1VnEkCkkRZxJQAC/Dhz0Jbfi22mFXChbtNg9w/Ybg=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "946e5fb82c3443940c45e5a61686d173e2e21155",
+        "rev": "69f57f27e52a87c54e28138a75ec741cd46663c9",
         "type": "github"
       },
       "original": {
@@ -617,11 +617,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775197701,
-        "narHash": "sha256-W9dcvnvbpZZexKVnDp/8NiNXqy2gnq1FWCD142/Skp8=",
+        "lastModified": 1776715674,
+        "narHash": "sha256-Gs1VnEkCkkRZxJQAC/Dhz0Jbfi22mFXChbtNg9w/Ybg=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "946e5fb82c3443940c45e5a61686d173e2e21155",
+        "rev": "69f57f27e52a87c54e28138a75ec741cd46663c9",
         "type": "github"
       },
       "original": {
@@ -633,11 +633,11 @@
     "resty-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1777221488,
-        "narHash": "sha256-/95BrY/Eiou0BouuCtlGp7NPE5yTjG0uVezxnuzPWZk=",
+        "lastModified": 1777303491,
+        "narHash": "sha256-IEa5lqlAXekQFqjb+Vjv1k+uZY4De19N9am+nBAXGLk=",
         "owner": "lima1909",
         "repo": "resty.nvim",
-        "rev": "6593c19f2ff93057562e41a9ee1b22503b7e5e91",
+        "rev": "7825ce662964e8e1aff926b1244faf52ad6bbdbb",
         "type": "github"
       },
       "original": {
@@ -803,11 +803,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1776840800,
-        "narHash": "sha256-ekfqqG44cS13FJ0qQKOCl8bftxF8BSRD5v+wZrCAvb8=",
+        "lastModified": 1777725261,
+        "narHash": "sha256-JPwaWFjW4W5ZKAnKEkMnK41JS4omsKYxmRerGMGALDc=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "506338434fec5ad19cb1f8d45bf92d66c4917393",
+        "rev": "ec009610d5d259ec59a6edf0219ef3f7ee4732e5",
         "type": "github"
       },
       "original": {
@@ -844,11 +844,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775195476,
-        "narHash": "sha256-uaPmLBiYfd6dpTJD8SI6+8Cg0ciUpHc5uN5EbFmd6SE=",
+        "lastModified": 1777463177,
+        "narHash": "sha256-1PcD0+IZPQXyvmXJ1OYH+23sRc9IyOKrUUBYZonVBm8=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "7fac30f496a7d9853e8c301a8edbfc35af50d418",
+        "rev": "6c53dcf4d3f63240f57e0b0c826cb15eda61f249",
         "type": "github"
       },
       "original": {
@@ -871,11 +871,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775195476,
-        "narHash": "sha256-uaPmLBiYfd6dpTJD8SI6+8Cg0ciUpHc5uN5EbFmd6SE=",
+        "lastModified": 1777463177,
+        "narHash": "sha256-1PcD0+IZPQXyvmXJ1OYH+23sRc9IyOKrUUBYZonVBm8=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "7fac30f496a7d9853e8c301a8edbfc35af50d418",
+        "rev": "6c53dcf4d3f63240f57e0b0c826cb15eda61f249",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/5c1b74905c7261e8280dcda3623dbe677a1bc158' (2026-05-01)
  → 'github:nix-community/home-manager/fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d' (2026-05-08)
• Updated input 'ltstatus':
    'github:dkuettel/ltstatus/b643f7aedd7163be8be4b7abd313581d32a24d22' (2026-04-08)
  → 'github:dkuettel/ltstatus/416fba2d6030977f6f11f60c18cfe06a1ff08a57' (2026-05-03)
• Updated input 'ltstatus/nixpkgs':
    'github:NixOS/nixpkgs/bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e' (2026-04-01)
  → 'github:NixOS/nixpkgs/755f5aa91337890c432639c60b6064bb7fe67769' (2026-04-29)
• Updated input 'ltstatus/pyproject-build-systems':
    'github:pyproject-nix/build-system-pkgs/b6e74f433b02fa4b8a7965ee24680f4867e2926f' (2026-03-18)
  → 'github:pyproject-nix/build-system-pkgs/ffaa2161dd5d63e0e94591f86b54fc239660fb2e' (2026-04-20)
• Updated input 'ltstatus/pyproject-nix':
    'github:pyproject-nix/pyproject.nix/946e5fb82c3443940c45e5a61686d173e2e21155' (2026-04-03)
  → 'github:pyproject-nix/pyproject.nix/69f57f27e52a87c54e28138a75ec741cd46663c9' (2026-04-20)
• Updated input 'ltstatus/uv2nix':
    'github:pyproject-nix/uv2nix/7fac30f496a7d9853e8c301a8edbfc35af50d418' (2026-04-03)
  → 'github:pyproject-nix/uv2nix/6c53dcf4d3f63240f57e0b0c826cb15eda61f249' (2026-04-29)
• Updated input 'nd':
    'github:dkuettel/nd/37f18c1712e99e39252e9cc40016a037cd43adbf' (2026-04-03)
  → 'github:dkuettel/nd/e5c0a6a37b6c7105a742fc612d1e526b18bc8141' (2026-05-03)
• Updated input 'nd/nixpkgs':
    'github:NixOS/nixpkgs/bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e' (2026-04-01)
  → 'github:NixOS/nixpkgs/755f5aa91337890c432639c60b6064bb7fe67769' (2026-04-29)
• Updated input 'nihilistic-nvim':
    'github:iff/nihilistic-nvim/117b0391ba030ac9481af7481f3fef80eddc07ec' (2026-04-27)
  → 'github:iff/nihilistic-nvim/10602ea28dd23772b4be33722be2619536d16650' (2026-05-04)
• Updated input 'nihilistic-nvim/funky-formatter-nvim':
    'github:dkuettel/funky-formatter.nvim/9307a67bccb0fc17698211ae05f1f30bf568038b' (2026-04-03)
  → 'github:dkuettel/funky-formatter.nvim/57bcb3b15af93b171b09cf84d84219fbc452543a' (2026-05-03)
• Updated input 'nihilistic-nvim/lualine-nvim':
    'github:nvim-lualine/lualine.nvim/a905eeebc4e63fdc48b5135d3bf8aea5618fb21c' (2026-04-12)
  → 'github:nvim-lualine/lualine.nvim/131a558e13f9f28b15cd235557150ccb23f89286' (2026-04-28)
• Updated input 'nihilistic-nvim/nightfox-nvim':
    'github:EdenEast/nightfox.nvim/ba47d4b4c5ec308718641ba7402c143836f35aa9' (2025-02-09)
  → 'github:EdenEast/nightfox.nvim/26b61b1f856ec37cae3cb64f5690adb955f246a1' (2026-05-03)
• Updated input 'nihilistic-nvim/nvim-lspconfig':
    'github:neovim/nvim-lspconfig/21db1fd40cbcbf1524ae154ab8f394fdf085749a' (2026-04-26)
  → 'github:neovim/nvim-lspconfig/31026a13eefb20681124706a79fc1df6bf11ab27' (2026-04-30)
• Updated input 'nihilistic-nvim/ptags-nvim':
    'github:dkuettel/ptags.nvim/b737c85e0cd5d3f7d1867508015edace194c4717' (2026-04-07)
  → 'github:dkuettel/ptags.nvim/0cde99f2c395968bceea9b0d871b84da600b5f2a' (2026-05-03)
• Updated input 'nihilistic-nvim/ptags-nvim/nixpkgs':
    'github:NixOS/nixpkgs/bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e' (2026-04-01)
  → 'github:NixOS/nixpkgs/755f5aa91337890c432639c60b6064bb7fe67769' (2026-04-29)
• Updated input 'nihilistic-nvim/ptags-nvim/pyproject-build-systems':
    'github:pyproject-nix/build-system-pkgs/b6e74f433b02fa4b8a7965ee24680f4867e2926f' (2026-03-18)
  → 'github:pyproject-nix/build-system-pkgs/ffaa2161dd5d63e0e94591f86b54fc239660fb2e' (2026-04-20)
• Updated input 'nihilistic-nvim/ptags-nvim/pyproject-nix':
    'github:pyproject-nix/pyproject.nix/946e5fb82c3443940c45e5a61686d173e2e21155' (2026-04-03)
  → 'github:pyproject-nix/pyproject.nix/69f57f27e52a87c54e28138a75ec741cd46663c9' (2026-04-20)
• Updated input 'nihilistic-nvim/ptags-nvim/uv2nix':
    'github:pyproject-nix/uv2nix/7fac30f496a7d9853e8c301a8edbfc35af50d418' (2026-04-03)
  → 'github:pyproject-nix/uv2nix/6c53dcf4d3f63240f57e0b0c826cb15eda61f249' (2026-04-29)
• Updated input 'nihilistic-nvim/resty-vim':
    'github:lima1909/resty.nvim/6593c19f2ff93057562e41a9ee1b22503b7e5e91' (2026-04-26)
  → 'github:lima1909/resty.nvim/7825ce662964e8e1aff926b1244faf52ad6bbdbb' (2026-04-27)
• Updated input 'nihilistic-nvim/telescope-nvim':
    'github:nvim-telescope/telescope.nvim/506338434fec5ad19cb1f8d45bf92d66c4917393' (2026-04-22)
  → 'github:nvim-telescope/telescope.nvim/ec009610d5d259ec59a6edf0219ef3f7ee4732e5' (2026-05-02)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/7aaa00e7cc9be6c316cb5f6617bd740dd435c59d' (2026-04-30)
  → 'github:nixos/nixpkgs/68a8af93ff4297686cb68880845e61e5e2e41d92' (2026-05-07)

```

</p></details>

 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`5c1b7490` ➡️ `fdb2ccba`](https://github.com/nix-community/home-manager/compare/5c1b74905c7261e8280dcda3623dbe677a1bc158...fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d) <sub>(2026-05-01 to 2026-05-08)<sub/>
 - Updated input [`ltstatus`](https://github.com/dkuettel/ltstatus): [`b643f7ae` ➡️ `416fba2d`](https://github.com/dkuettel/ltstatus/compare/b643f7aedd7163be8be4b7abd313581d32a24d22...416fba2d6030977f6f11f60c18cfe06a1ff08a57) <sub>(2026-04-08 to 2026-05-03)<sub/>
 - Updated input [`ltstatus/nixpkgs`](https://github.com/NixOS/nixpkgs): [`bcd464cc` ➡️ `755f5aa9`](https://github.com/NixOS/nixpkgs/compare/bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e...755f5aa91337890c432639c60b6064bb7fe67769) <sub>(2026-04-01 to 2026-04-29)<sub/>
 - Updated input [`ltstatus/pyproject-build-systems`](https://github.com/pyproject-nix/build-system-pkgs): [`b6e74f43` ➡️ `ffaa2161`](https://github.com/pyproject-nix/build-system-pkgs/compare/b6e74f433b02fa4b8a7965ee24680f4867e2926f...ffaa2161dd5d63e0e94591f86b54fc239660fb2e) <sub>(2026-03-18 to 2026-04-20)<sub/>
 - Updated input [`ltstatus/pyproject-nix`](https://github.com/pyproject-nix/pyproject.nix): [`946e5fb8` ➡️ `69f57f27`](https://github.com/pyproject-nix/pyproject.nix/compare/946e5fb82c3443940c45e5a61686d173e2e21155...69f57f27e52a87c54e28138a75ec741cd46663c9) <sub>(2026-04-03 to 2026-04-20)<sub/>
 - Updated input [`ltstatus/uv2nix`](https://github.com/pyproject-nix/uv2nix): [`7fac30f4` ➡️ `6c53dcf4`](https://github.com/pyproject-nix/uv2nix/compare/7fac30f496a7d9853e8c301a8edbfc35af50d418...6c53dcf4d3f63240f57e0b0c826cb15eda61f249) <sub>(2026-04-03 to 2026-04-29)<sub/>
 - Updated input [`nd`](https://github.com/dkuettel/nd): [`37f18c17` ➡️ `e5c0a6a3`](https://github.com/dkuettel/nd/compare/37f18c1712e99e39252e9cc40016a037cd43adbf...e5c0a6a37b6c7105a742fc612d1e526b18bc8141) <sub>(2026-04-03 to 2026-05-03)<sub/>
 - Updated input [`nd/nixpkgs`](https://github.com/NixOS/nixpkgs): [`bcd464cc` ➡️ `755f5aa9`](https://github.com/NixOS/nixpkgs/compare/bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e...755f5aa91337890c432639c60b6064bb7fe67769) <sub>(2026-04-01 to 2026-04-29)<sub/>
 - Updated input [`nihilistic-nvim`](https://github.com/iff/nihilistic-nvim): [`117b0391` ➡️ `10602ea2`](https://github.com/iff/nihilistic-nvim/compare/117b0391ba030ac9481af7481f3fef80eddc07ec...10602ea28dd23772b4be33722be2619536d16650) <sub>(2026-04-27 to 2026-05-04)<sub/>
 - Updated input [`nihilistic-nvim/funky-formatter-nvim`](https://github.com/dkuettel/funky-formatter.nvim): [`9307a67b` ➡️ `57bcb3b1`](https://github.com/dkuettel/funky-formatter.nvim/compare/9307a67bccb0fc17698211ae05f1f30bf568038b...57bcb3b15af93b171b09cf84d84219fbc452543a) <sub>(2026-04-03 to 2026-05-03)<sub/>
 - Updated input [`nihilistic-nvim/lualine-nvim`](https://github.com/nvim-lualine/lualine.nvim): [`a905eeeb` ➡️ `131a558e`](https://github.com/nvim-lualine/lualine.nvim/compare/a905eeebc4e63fdc48b5135d3bf8aea5618fb21c...131a558e13f9f28b15cd235557150ccb23f89286) <sub>(2026-04-12 to 2026-04-28)<sub/>
 - Updated input [`nihilistic-nvim/nightfox-nvim`](https://github.com/EdenEast/nightfox.nvim): [`ba47d4b4` ➡️ `26b61b1f`](https://github.com/EdenEast/nightfox.nvim/compare/ba47d4b4c5ec308718641ba7402c143836f35aa9...26b61b1f856ec37cae3cb64f5690adb955f246a1) <sub>(2025-02-09 to 2026-05-03)<sub/>
 - Updated input [`nihilistic-nvim/nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`21db1fd4` ➡️ `31026a13`](https://github.com/neovim/nvim-lspconfig/compare/21db1fd40cbcbf1524ae154ab8f394fdf085749a...31026a13eefb20681124706a79fc1df6bf11ab27) <sub>(2026-04-26 to 2026-04-30)<sub/>
 - Updated input [`nihilistic-nvim/ptags-nvim`](https://github.com/dkuettel/ptags.nvim): [`b737c85e` ➡️ `0cde99f2`](https://github.com/dkuettel/ptags.nvim/compare/b737c85e0cd5d3f7d1867508015edace194c4717...0cde99f2c395968bceea9b0d871b84da600b5f2a) <sub>(2026-04-07 to 2026-05-03)<sub/>
 - Updated input [`nihilistic-nvim/ptags-nvim/nixpkgs`](https://github.com/NixOS/nixpkgs): [`bcd464cc` ➡️ `755f5aa9`](https://github.com/NixOS/nixpkgs/compare/bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e...755f5aa91337890c432639c60b6064bb7fe67769) <sub>(2026-04-01 to 2026-04-29)<sub/>
 - Updated input [`nihilistic-nvim/ptags-nvim/pyproject-build-systems`](https://github.com/pyproject-nix/build-system-pkgs): [`b6e74f43` ➡️ `ffaa2161`](https://github.com/pyproject-nix/build-system-pkgs/compare/b6e74f433b02fa4b8a7965ee24680f4867e2926f...ffaa2161dd5d63e0e94591f86b54fc239660fb2e) <sub>(2026-03-18 to 2026-04-20)<sub/>
 - Updated input [`nihilistic-nvim/ptags-nvim/pyproject-nix`](https://github.com/pyproject-nix/pyproject.nix): [`946e5fb8` ➡️ `69f57f27`](https://github.com/pyproject-nix/pyproject.nix/compare/946e5fb82c3443940c45e5a61686d173e2e21155...69f57f27e52a87c54e28138a75ec741cd46663c9) <sub>(2026-04-03 to 2026-04-20)<sub/>
 - Updated input [`nihilistic-nvim/ptags-nvim/uv2nix`](https://github.com/pyproject-nix/uv2nix): [`7fac30f4` ➡️ `6c53dcf4`](https://github.com/pyproject-nix/uv2nix/compare/7fac30f496a7d9853e8c301a8edbfc35af50d418...6c53dcf4d3f63240f57e0b0c826cb15eda61f249) <sub>(2026-04-03 to 2026-04-29)<sub/>
 - Updated input [`nihilistic-nvim/resty-vim`](https://github.com/lima1909/resty.nvim): [`6593c19f` ➡️ `7825ce66`](https://github.com/lima1909/resty.nvim/compare/6593c19f2ff93057562e41a9ee1b22503b7e5e91...7825ce662964e8e1aff926b1244faf52ad6bbdbb) <sub>(2026-04-26 to 2026-04-27)<sub/>
 - Updated input [`nihilistic-nvim/telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`50633843` ➡️ `ec009610`](https://github.com/nvim-telescope/telescope.nvim/compare/506338434fec5ad19cb1f8d45bf92d66c4917393...ec009610d5d259ec59a6edf0219ef3f7ee4732e5) <sub>(2026-04-22 to 2026-05-02)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`7aaa00e7` ➡️ `68a8af93`](https://github.com/nixos/nixpkgs/compare/7aaa00e7cc9be6c316cb5f6617bd740dd435c59d...68a8af93ff4297686cb68880845e61e5e2e41d92) <sub>(2026-04-30 to 2026-05-07)<sub/>