### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778248595,
-        "narHash": "sha256-dhFgEjoeJMYN/7OY6xfxS799YB4IjbbYXTjyGIJyLpc=",
+        "lastModified": 1778876681,
+        "narHash": "sha256-9XOIxYLBp+sJsPWNnNyk1aVfYXuuRJZ4Anpplm9Tn8g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d",
+        "rev": "c7fad8197070948d8aa02cb8922240ee129cab2e",
         "type": "github"
       },
       "original": {
@@ -197,11 +197,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1776426061,
-        "narHash": "sha256-3rROoGl8xBsIOM+5m+qZS4GJnsdQPAH3NJJe1OUfJ5o=",
+        "lastModified": 1778488488,
+        "narHash": "sha256-6Vvr0qMRdccvJqwzrXJkqoK6lWsdyC1nMrLjoHKqoGM=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "1f71628d86a7701fd5ba0f8aeabe15376f4c6afc",
+        "rev": "55b1393a23d6e4968ce6da704c8095f7e5e9fa3c",
         "type": "github"
       },
       "original": {
@@ -356,11 +356,11 @@
         "telescope-ui-select-nvim": "telescope-ui-select-nvim"
       },
       "locked": {
-        "lastModified": 1778756899,
-        "narHash": "sha256-6eJZoFfymd6sVt6hiEiMS3LzyzGakfzes0stdjUudqg=",
+        "lastModified": 1778856215,
+        "narHash": "sha256-+jZff7hhOnUYxWoNvqwcyxymuiPkF7C84BPGo/Op+Co=",
         "owner": "iff",
         "repo": "nihilistic-nvim",
-        "rev": "f2b53f75c363f00dba55087c9a561e5ccb5346a1",
+        "rev": "177342c8e494e4fd87346e07aa76ef2b49c8db35",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1778124196,
-        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
+        "lastModified": 1778794387,
+        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
+        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
         "type": "github"
       },
       "original": {
@@ -490,11 +490,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1777231889,
-        "narHash": "sha256-W29cG5DJUi7SDUwAedFx9tHMUL3p7/9YOYYHTRCEiU0=",
+        "lastModified": 1778759077,
+        "narHash": "sha256-VJ4yc8l39tDXqwk+Hs3VMI6jz3z4Nb7o63Y6JY73tO4=",
         "owner": "iff",
         "repo": "osh-oxy",
-        "rev": "eeaef76df2c680681809b40880c004938bd18324",
+        "rev": "208d1391db2cc8ede18084e11eeaa628a33de0b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d' (2026-05-08)
  → 'github:nix-community/home-manager/c7fad8197070948d8aa02cb8922240ee129cab2e' (2026-05-15)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/1f71628d86a7701fd5ba0f8aeabe15376f4c6afc' (2026-04-17)
  → 'github:hyprwm/contrib/55b1393a23d6e4968ce6da704c8095f7e5e9fa3c' (2026-05-11)
• Updated input 'nihilistic-nvim':
    'github:iff/nihilistic-nvim/f2b53f75c363f00dba55087c9a561e5ccb5346a1' (2026-05-14)
  → 'github:iff/nihilistic-nvim/177342c8e494e4fd87346e07aa76ef2b49c8db35' (2026-05-15)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/68a8af93ff4297686cb68880845e61e5e2e41d92' (2026-05-07)
  → 'github:nixos/nixpkgs/8a1b0127302ea51e05bf4ea5a291743fac442406' (2026-05-14)
• Updated input 'osh-oxy':
    'github:iff/osh-oxy/eeaef76df2c680681809b40880c004938bd18324' (2026-04-26)
  → 'github:iff/osh-oxy/208d1391db2cc8ede18084e11eeaa628a33de0b9' (2026-05-14)
```

</p></details>

 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`fdb2ccba` ➡️ `c7fad819`](https://github.com/nix-community/home-manager/compare/fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d...c7fad8197070948d8aa02cb8922240ee129cab2e) <sub>(2026-05-08 to 2026-05-15)<sub/>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`1f71628d` ➡️ `55b1393a`](https://github.com/hyprwm/contrib/compare/1f71628d86a7701fd5ba0f8aeabe15376f4c6afc...55b1393a23d6e4968ce6da704c8095f7e5e9fa3c) <sub>(2026-04-17 to 2026-05-11)<sub/>
 - Updated input [`nihilistic-nvim`](https://github.com/iff/nihilistic-nvim): [`f2b53f75` ➡️ `177342c8`](https://github.com/iff/nihilistic-nvim/compare/f2b53f75c363f00dba55087c9a561e5ccb5346a1...177342c8e494e4fd87346e07aa76ef2b49c8db35) <sub>(2026-05-14 to 2026-05-15)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`68a8af93` ➡️ `8a1b0127`](https://github.com/nixos/nixpkgs/compare/68a8af93ff4297686cb68880845e61e5e2e41d92...8a1b0127302ea51e05bf4ea5a291743fac442406) <sub>(2026-05-07 to 2026-05-14)<sub/>
 - Updated input [`osh-oxy`](https://github.com/iff/osh-oxy): [`eeaef76d` ➡️ `208d1391`](https://github.com/iff/osh-oxy/compare/eeaef76df2c680681809b40880c004938bd18324...208d1391db2cc8ede18084e11eeaa628a33de0b9) <sub>(2026-04-26 to 2026-05-14)<sub/>