### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778876681,
-        "narHash": "sha256-9XOIxYLBp+sJsPWNnNyk1aVfYXuuRJZ4Anpplm9Tn8g=",
+        "lastModified": 1779336838,
+        "narHash": "sha256-n1+l78hJRABp4cQHKeD0BVByT0vZLPqd09Tvoq8Q+d8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c7fad8197070948d8aa02cb8922240ee129cab2e",
+        "rev": "928d72376949e222ea4f07b44828a55b0136422e",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1778794387,
-        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
+        "lastModified": 1779414690,
+        "narHash": "sha256-gOTcX/9MZVMUE0Xvb4IEcv+0TQJkZFNEnL757ljU360=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
+        "rev": "6dedf69f94d03cbe7bdde106f2d4c23ae2a853bf",
         "type": "github"
       },
       "original": {
@@ -490,11 +490,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1778759077,
-        "narHash": "sha256-VJ4yc8l39tDXqwk+Hs3VMI6jz3z4Nb7o63Y6JY73tO4=",
+        "lastModified": 1779477157,
+        "narHash": "sha256-vrzdvoRu+FcplD9TL5D6z5CzGq/7pJz6gxcnFSkebRw=",
         "owner": "iff",
         "repo": "osh-oxy",
-        "rev": "208d1391db2cc8ede18084e11eeaa628a33de0b9",
+        "rev": "6d449cfb6e38c07284078c6a206224dd33e7311b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -435,11 +435,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1779414690,
-        "narHash": "sha256-gOTcX/9MZVMUE0Xvb4IEcv+0TQJkZFNEnL757ljU360=",
+        "lastModified": 1779536132,
+        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6dedf69f94d03cbe7bdde106f2d4c23ae2a853bf",
+        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/c7fad8197070948d8aa02cb8922240ee129cab2e' (2026-05-15)
  → 'github:nix-community/home-manager/928d72376949e222ea4f07b44828a55b0136422e' (2026-05-21)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/8a1b0127302ea51e05bf4ea5a291743fac442406' (2026-05-14)
  → 'github:nixos/nixpkgs/6dedf69f94d03cbe7bdde106f2d4c23ae2a853bf' (2026-05-22)
• Updated input 'osh-oxy':
    'github:iff/osh-oxy/208d1391db2cc8ede18084e11eeaa628a33de0b9' (2026-05-14)
  → 'github:iff/osh-oxy/6d449cfb6e38c07284078c6a206224dd33e7311b' (2026-05-22)
```

</p></details>

 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`c7fad819` ➡️ `928d7237`](https://github.com/nix-community/home-manager/compare/c7fad8197070948d8aa02cb8922240ee129cab2e...928d72376949e222ea4f07b44828a55b0136422e) <sub>(2026-05-15 to 2026-05-21)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`8a1b0127` ➡️ `6dedf69f`](https://github.com/nixos/nixpkgs/compare/8a1b0127302ea51e05bf4ea5a291743fac442406...6dedf69f94d03cbe7bdde106f2d4c23ae2a853bf) <sub>(2026-05-14 to 2026-05-22)<sub/>
 - Updated input [`osh-oxy`](https://github.com/iff/osh-oxy): [`208d1391` ➡️ `6d449cfb`](https://github.com/iff/osh-oxy/compare/208d1391db2cc8ede18084e11eeaa628a33de0b9...6d449cfb6e38c07284078c6a206224dd33e7311b) <sub>(2026-05-14 to 2026-05-22)<sub/>