### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779336838,
-        "narHash": "sha256-n1+l78hJRABp4cQHKeD0BVByT0vZLPqd09Tvoq8Q+d8=",
+        "lastModified": 1779969295,
+        "narHash": "sha256-HwIJ3tOcwSMiV75L7KqJXciXR9UfT+d7rwOZMX7cTnA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "928d72376949e222ea4f07b44828a55b0136422e",
+        "rev": "61e2c9659324181e0f0ed911958c536333b1d4f6",
         "type": "github"
       },
       "original": {
@@ -197,11 +197,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1778488488,
-        "narHash": "sha256-6Vvr0qMRdccvJqwzrXJkqoK6lWsdyC1nMrLjoHKqoGM=",
+        "lastModified": 1780083791,
+        "narHash": "sha256-epTJKmTCNL1Hm6/YdEWAgiOMVBSzC9/v/rjyOieP3yA=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "55b1393a23d6e4968ce6da704c8095f7e5e9fa3c",
+        "rev": "bf1a7cdb086587e6bed6e8ecd285a81c01a11c54",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1779536132,
-        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
+        "lastModified": 1779877693,
+        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
+        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
         "type": "github"
       },
       "original": {
@@ -490,11 +490,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1779477157,
-        "narHash": "sha256-vrzdvoRu+FcplD9TL5D6z5CzGq/7pJz6gxcnFSkebRw=",
+        "lastModified": 1779956523,
+        "narHash": "sha256-EHBrhee9SJkjv1hu2xjWmBQ99QuOhpw8SYXSNsaamM8=",
         "owner": "iff",
         "repo": "osh-oxy",
-        "rev": "6d449cfb6e38c07284078c6a206224dd33e7311b",
+        "rev": "7141d5d8748fc733cf58cb65e80b216c671c795b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/928d72376949e222ea4f07b44828a55b0136422e' (2026-05-21)
  → 'github:nix-community/home-manager/61e2c9659324181e0f0ed911958c536333b1d4f6' (2026-05-28)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/55b1393a23d6e4968ce6da704c8095f7e5e9fa3c' (2026-05-11)
  → 'github:hyprwm/contrib/bf1a7cdb086587e6bed6e8ecd285a81c01a11c54' (2026-05-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456' (2026-05-23)
  → 'github:nixos/nixpkgs/4100e830e085863741bc69b156ec4ccd53ab5be0' (2026-05-27)
• Updated input 'osh-oxy':
    'github:iff/osh-oxy/6d449cfb6e38c07284078c6a206224dd33e7311b' (2026-05-22)
  → 'github:iff/osh-oxy/7141d5d8748fc733cf58cb65e80b216c671c795b' (2026-05-28)
```

</p></details>

 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`928d7237` ➡️ `61e2c965`](https://github.com/nix-community/home-manager/compare/928d72376949e222ea4f07b44828a55b0136422e...61e2c9659324181e0f0ed911958c536333b1d4f6) <sub>(2026-05-21 to 2026-05-28)<sub/>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`55b1393a` ➡️ `bf1a7cdb`](https://github.com/hyprwm/contrib/compare/55b1393a23d6e4968ce6da704c8095f7e5e9fa3c...bf1a7cdb086587e6bed6e8ecd285a81c01a11c54) <sub>(2026-05-11 to 2026-05-29)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`3d8f0f3f` ➡️ `4100e830`](https://github.com/nixos/nixpkgs/compare/3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456...4100e830e085863741bc69b156ec4ccd53ab5be0) <sub>(2026-05-23 to 2026-05-27)<sub/>
 - Updated input [`osh-oxy`](https://github.com/iff/osh-oxy): [`6d449cfb` ➡️ `7141d5d8`](https://github.com/iff/osh-oxy/compare/6d449cfb6e38c07284078c6a206224dd33e7311b...7141d5d8748fc733cf58cb65e80b216c671c795b) <sub>(2026-05-22 to 2026-05-28)<sub/>