### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779969295,
-        "narHash": "sha256-HwIJ3tOcwSMiV75L7KqJXciXR9UfT+d7rwOZMX7cTnA=",
+        "lastModified": 1780679734,
+        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "61e2c9659324181e0f0ed911958c536333b1d4f6",
+        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1777811630,
-        "narHash": "sha256-CJBlOKf2RSwIw2WuiCDoauKZkiIza/RrXKxjPSZu8N4=",
+        "lastModified": 1780519520,
+        "narHash": "sha256-si+MUZEZqrvcFuBeTeOfGk3qg/X/yPsL6TENPtq1iOo=",
         "owner": "dkuettel",
         "repo": "ltstatus",
-        "rev": "416fba2d6030977f6f11f60c18cfe06a1ff08a57",
+        "rev": "9f288eb5e00c4b23a3f415fcd3b7c66cc375aec5",
         "type": "github"
       },
       "original": {
@@ -304,11 +304,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1777811709,
-        "narHash": "sha256-5jVac2kyl7HKQLDk/Ijnb91C5zLRJuDxNoz+ouMQSz4=",
+        "lastModified": 1780519657,
+        "narHash": "sha256-1HFit0smxQ5irRUBbVU0N+BhBGTkQzfCExx62p+Iv/k=",
         "owner": "dkuettel",
         "repo": "nd",
-        "rev": "e5c0a6a37b6c7105a742fc612d1e526b18bc8141",
+        "rev": "6768f39f14a0aa6abb5c8dc13d4f401ca1f253f0",
         "type": "github"
       },
       "original": {
@@ -387,32 +387,32 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1777428379,
-        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
         "type": "github"
       },
       "original": {
-        "owner": "dkuettel",
-        "ref": "stable",
+        "owner": "nixos",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1777428379,
-        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
         "type": "github"
       },
       "original": {
-        "owner": "dkuettel",
-        "ref": "stable",
+        "owner": "nixos",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -435,11 +435,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1779877693,
-        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
+        "lastModified": 1780365719,
+        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
+        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
         "type": "github"
       },
       "original": {
@@ -490,11 +490,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1779956523,
-        "narHash": "sha256-EHBrhee9SJkjv1hu2xjWmBQ99QuOhpw8SYXSNsaamM8=",
+        "lastModified": 1780383757,
+        "narHash": "sha256-nFluaCerT7xoqEhfN+ZJraWDBP4N6lf8qCKFYid+fkA=",
         "owner": "iff",
         "repo": "osh-oxy",
-        "rev": "7141d5d8748fc733cf58cb65e80b216c671c795b",
+        "rev": "d4d8c34c6b2253927ee518d8bbc737690bc49aba",
         "type": "github"
       },
       "original": {
@@ -541,11 +541,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776659114,
-        "narHash": "sha256-qapCOQmR++yZSY43dzrp3wCrkOTLpod+ONtJWBk6iKU=",
+        "lastModified": 1779676664,
+        "narHash": "sha256-MbXylBTkWqVm8/VYjoULtMoVRgWBN1gSHbeRKsOsPlU=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "ffaa2161dd5d63e0e94591f86b54fc239660fb2e",
+        "rev": "7bff980f37fc24e09dbc986643719900c139bf12",
         "type": "github"
       },
       "original": {
@@ -594,11 +594,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776715674,
-        "narHash": "sha256-Gs1VnEkCkkRZxJQAC/Dhz0Jbfi22mFXChbtNg9w/Ybg=",
+        "lastModified": 1780416763,
+        "narHash": "sha256-rRK3IFixgsrK6S3e14Xz9HAZm7+kMAIl3oi5zZlcwYI=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "69f57f27e52a87c54e28138a75ec741cd46663c9",
+        "rev": "ad83f1ead0e78e57b188f35cb57298affb06fc5f",
         "type": "github"
       },
       "original": {
@@ -827,11 +827,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777463177,
-        "narHash": "sha256-1PcD0+IZPQXyvmXJ1OYH+23sRc9IyOKrUUBYZonVBm8=",
+        "lastModified": 1780418295,
+        "narHash": "sha256-yZVQNvmDx1SFjvlwevywsXWJnieSRqmQr7/fCTMyyd0=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "6c53dcf4d3f63240f57e0b0c826cb15eda61f249",
+        "rev": "0497ccef038da091002be7c05263a7f27820974f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/61e2c9659324181e0f0ed911958c536333b1d4f6' (2026-05-28)
  → 'github:nix-community/home-manager/b2b7db486e06e098711dc291bb25db82850e1d16' (2026-06-05)
• Updated input 'ltstatus':
    'github:dkuettel/ltstatus/416fba2d6030977f6f11f60c18cfe06a1ff08a57' (2026-05-03)
  → 'github:dkuettel/ltstatus/9f288eb5e00c4b23a3f415fcd3b7c66cc375aec5' (2026-06-03)
• Updated input 'ltstatus/nixpkgs':
    'github:NixOS/nixpkgs/755f5aa91337890c432639c60b6064bb7fe67769' (2026-04-29)
  → 'github:NixOS/nixpkgs/b51242d7d43689db2f3be91bd05d5b24fbb469c4' (2026-05-31)
• Updated input 'ltstatus/pyproject-build-systems':
    'github:pyproject-nix/build-system-pkgs/ffaa2161dd5d63e0e94591f86b54fc239660fb2e' (2026-04-20)
  → 'github:pyproject-nix/build-system-pkgs/7bff980f37fc24e09dbc986643719900c139bf12' (2026-05-25)
• Updated input 'ltstatus/pyproject-nix':
    'github:pyproject-nix/pyproject.nix/69f57f27e52a87c54e28138a75ec741cd46663c9' (2026-04-20)
  → 'github:pyproject-nix/pyproject.nix/ad83f1ead0e78e57b188f35cb57298affb06fc5f' (2026-06-02)
• Updated input 'ltstatus/uv2nix':
    'github:pyproject-nix/uv2nix/6c53dcf4d3f63240f57e0b0c826cb15eda61f249' (2026-04-29)
  → 'github:pyproject-nix/uv2nix/0497ccef038da091002be7c05263a7f27820974f' (2026-06-02)
• Updated input 'nd':
    'github:dkuettel/nd/e5c0a6a37b6c7105a742fc612d1e526b18bc8141' (2026-05-03)
  → 'github:dkuettel/nd/6768f39f14a0aa6abb5c8dc13d4f401ca1f253f0' (2026-06-03)
• Updated input 'nd/nixpkgs':
    'github:NixOS/nixpkgs/755f5aa91337890c432639c60b6064bb7fe67769' (2026-04-29)
  → 'github:NixOS/nixpkgs/b51242d7d43689db2f3be91bd05d5b24fbb469c4' (2026-05-31)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/4100e830e085863741bc69b156ec4ccd53ab5be0' (2026-05-27)
  → 'github:nixos/nixpkgs/ffa10e26ae11d676b2db836259889f1f571cb14f' (2026-06-02)
• Updated input 'osh-oxy':
    'github:iff/osh-oxy/7141d5d8748fc733cf58cb65e80b216c671c795b' (2026-05-28)
  → 'github:iff/osh-oxy/d4d8c34c6b2253927ee518d8bbc737690bc49aba' (2026-06-02)
```

</p></details>

 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`61e2c965` ➡️ `b2b7db48`](https://github.com/nix-community/home-manager/compare/61e2c9659324181e0f0ed911958c536333b1d4f6...b2b7db486e06e098711dc291bb25db82850e1d16) <sub>(2026-05-28 to 2026-06-05)<sub/>
 - Updated input [`ltstatus`](https://github.com/dkuettel/ltstatus): [`416fba2d` ➡️ `9f288eb5`](https://github.com/dkuettel/ltstatus/compare/416fba2d6030977f6f11f60c18cfe06a1ff08a57...9f288eb5e00c4b23a3f415fcd3b7c66cc375aec5) <sub>(2026-05-03 to 2026-06-03)<sub/>
 - Updated input [`ltstatus/nixpkgs`](https://github.com/NixOS/nixpkgs): [`755f5aa9` ➡️ `b51242d7`](https://github.com/NixOS/nixpkgs/compare/755f5aa91337890c432639c60b6064bb7fe67769...b51242d7d43689db2f3be91bd05d5b24fbb469c4) <sub>(2026-04-29 to 2026-05-31)<sub/>
 - Updated input [`ltstatus/pyproject-build-systems`](https://github.com/pyproject-nix/build-system-pkgs): [`ffaa2161` ➡️ `7bff980f`](https://github.com/pyproject-nix/build-system-pkgs/compare/ffaa2161dd5d63e0e94591f86b54fc239660fb2e...7bff980f37fc24e09dbc986643719900c139bf12) <sub>(2026-04-20 to 2026-05-25)<sub/>
 - Updated input [`ltstatus/pyproject-nix`](https://github.com/pyproject-nix/pyproject.nix): [`69f57f27` ➡️ `ad83f1ea`](https://github.com/pyproject-nix/pyproject.nix/compare/69f57f27e52a87c54e28138a75ec741cd46663c9...ad83f1ead0e78e57b188f35cb57298affb06fc5f) <sub>(2026-04-20 to 2026-06-02)<sub/>
 - Updated input [`ltstatus/uv2nix`](https://github.com/pyproject-nix/uv2nix): [`6c53dcf4` ➡️ `0497ccef`](https://github.com/pyproject-nix/uv2nix/compare/6c53dcf4d3f63240f57e0b0c826cb15eda61f249...0497ccef038da091002be7c05263a7f27820974f) <sub>(2026-04-29 to 2026-06-02)<sub/>
 - Updated input [`nd`](https://github.com/dkuettel/nd): [`e5c0a6a3` ➡️ `6768f39f`](https://github.com/dkuettel/nd/compare/e5c0a6a37b6c7105a742fc612d1e526b18bc8141...6768f39f14a0aa6abb5c8dc13d4f401ca1f253f0) <sub>(2026-05-03 to 2026-06-03)<sub/>
 - Updated input [`nd/nixpkgs`](https://github.com/NixOS/nixpkgs): [`755f5aa9` ➡️ `b51242d7`](https://github.com/NixOS/nixpkgs/compare/755f5aa91337890c432639c60b6064bb7fe67769...b51242d7d43689db2f3be91bd05d5b24fbb469c4) <sub>(2026-04-29 to 2026-05-31)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`4100e830` ➡️ `ffa10e26`](https://github.com/nixos/nixpkgs/compare/4100e830e085863741bc69b156ec4ccd53ab5be0...ffa10e26ae11d676b2db836259889f1f571cb14f) <sub>(2026-05-27 to 2026-06-02)<sub/>
 - Updated input [`osh-oxy`](https://github.com/iff/osh-oxy): [`7141d5d8` ➡️ `d4d8c34c`](https://github.com/iff/osh-oxy/compare/7141d5d8748fc733cf58cb65e80b216c671c795b...d4d8c34c6b2253927ee518d8bbc737690bc49aba) <sub>(2026-05-28 to 2026-06-02)<sub/>