### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780679734,
-        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
+        "lastModified": 1781189114,
+        "narHash": "sha256-5inaamLgUMWy+MOBE9ChF9QAF1o/74LFuHkI0W/9rqc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
+        "rev": "486595d2cf49cfcd649b58a284fa11ac0e34da22",
         "type": "github"
       },
       "original": {
@@ -401,11 +401,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1780365719,
-        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
+        "lastModified": 1781229721,
+        "narHash": "sha256-ORvqDbb/LYxiJljGIejapjkc/kJbVote2N1WSb9W45I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
+        "rev": "173d0ad7a974f8543a9ab01d2271b2e290341b33",
         "type": "github"
       },
       "original": {
@@ -456,11 +456,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1780383757,
-        "narHash": "sha256-nFluaCerT7xoqEhfN+ZJraWDBP4N6lf8qCKFYid+fkA=",
+        "lastModified": 1781011643,
+        "narHash": "sha256-amnoD0ijNTDul2x4sK2MHzfCh8EvOidb8y0mWf6IQ44=",
         "owner": "iff",
         "repo": "osh-oxy",
-        "rev": "d4d8c34c6b2253927ee518d8bbc737690bc49aba",
+        "rev": "3a4c4a81ca614305790723704a8f41027d4de9d5",
         "type": "github"
       },
       "original": {
@@ -840,11 +840,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780735567,
-        "narHash": "sha256-hE7PFVE7CmLUALHwSfNWhwwXcy9ORiXYd4aP2Mg+c80=",
+        "lastModified": 1781274747,
+        "narHash": "sha256-9Bygkw28xVyxkPRmxIWSI0I20e6k8a8+CoxvdrUXscs=",
         "owner": "michel-kraemer",
         "repo": "zsh-patina",
-        "rev": "efe6e7593b9b21959996f0eee03b12db988b3e13",
+        "rev": "99bec55ea79aad4d07084c59389fc4c745a65424",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/b2b7db486e06e098711dc291bb25db82850e1d16' (2026-06-05)
  → 'github:nix-community/home-manager/486595d2cf49cfcd649b58a284fa11ac0e34da22' (2026-06-11)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/ffa10e26ae11d676b2db836259889f1f571cb14f' (2026-06-02)
  → 'github:nixos/nixpkgs/173d0ad7a974f8543a9ab01d2271b2e290341b33' (2026-06-12)
• Updated input 'osh-oxy':
    'github:iff/osh-oxy/d4d8c34c6b2253927ee518d8bbc737690bc49aba' (2026-06-02)
  → 'github:iff/osh-oxy/3a4c4a81ca614305790723704a8f41027d4de9d5' (2026-06-09)
• Updated input 'zsh-patina':
    'github:michel-kraemer/zsh-patina/efe6e7593b9b21959996f0eee03b12db988b3e13' (2026-06-06)
  → 'github:michel-kraemer/zsh-patina/99bec55ea79aad4d07084c59389fc4c745a65424' (2026-06-12)
```

</p></details>

 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`b2b7db48` ➡️ `486595d2`](https://github.com/nix-community/home-manager/compare/b2b7db486e06e098711dc291bb25db82850e1d16...486595d2cf49cfcd649b58a284fa11ac0e34da22) <sub>(2026-06-05 to 2026-06-11)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`ffa10e26` ➡️ `173d0ad7`](https://github.com/nixos/nixpkgs/compare/ffa10e26ae11d676b2db836259889f1f571cb14f...173d0ad7a974f8543a9ab01d2271b2e290341b33) <sub>(2026-06-02 to 2026-06-12)<sub/>
 - Updated input [`osh-oxy`](https://github.com/iff/osh-oxy): [`d4d8c34c` ➡️ `3a4c4a81`](https://github.com/iff/osh-oxy/compare/d4d8c34c6b2253927ee518d8bbc737690bc49aba...3a4c4a81ca614305790723704a8f41027d4de9d5) <sub>(2026-06-02 to 2026-06-09)<sub/>
 - Updated input [`zsh-patina`](https://github.com/michel-kraemer/zsh-patina): [`efe6e759` ➡️ `99bec55e`](https://github.com/michel-kraemer/zsh-patina/compare/efe6e7593b9b21959996f0eee03b12db988b3e13...99bec55ea79aad4d07084c59389fc4c745a65424) <sub>(2026-06-06 to 2026-06-12)<sub/>